### PR TITLE
Replace io/ioutil with io/os equivalents

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -274,7 +274,7 @@ func decryptPrivateKeyToken(key *PrivateKey, userKeyRing openpgp.EntityList) ([]
 		return nil, err
 	}
 
-	b, err := ioutil.ReadAll(md.UnverifiedBody)
+	b, err := io.ReadAll(md.UnverifiedBody)
 	if err != nil {
 		return nil, err
 	}

--- a/crypto.go
+++ b/crypto.go
@@ -224,7 +224,7 @@ func (s signatureWriter) Close() error {
 	return s.encryptedData.Close()
 }
 
-// noOpCloser is like an ioutil.NopCloser, but for an io.Writer.
+// noOpCloser is like an io.NopCloser, but for an io.Writer.
 type noOpCloser struct {
 	w io.Writer
 }

--- a/protonmail.go
+++ b/protonmail.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
@@ -113,7 +112,7 @@ func (c *Client) newJSONRequest(method, path string, body interface{}) (*http.Re
 
 	req.Header.Set("Content-Type", "application/json")
 	req.GetBody = func() (io.ReadCloser, error) {
-		return ioutil.NopCloser(bytes.NewReader(b)), nil
+		return io.NopCloser(bytes.NewReader(b)), nil
 	}
 	return req, nil
 }


### PR DESCRIPTION
Closes #1

Drops the deprecated `io/ioutil` import in favor of `io`/`os` equivalents:
- `ioutil.NopCloser` → `io.NopCloser` (protonmail.go)
- `ioutil.ReadAll` → `io.ReadAll` (auth.go)
- Stale comment in crypto.go updated to match.

**Acceptance**
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `grep -rn ioutil --include='*.go' .` returns empty
- [x] `staticcheck -checks=SA1019 ./...` clean (verified locally by Navigator)

**Pair-programming flow**
- Implementer: Driver agent
- Reviewer: Navigator agent (verdict: APPROVE)