### PR TITLE
Add GitHub Actions CI workflow and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    target-branch: main
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - go
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: main
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test (go ${{ matrix.go-version }} / ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ['1.25']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          check-latest: true
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test -coverprofile=coverage.out ./...
+
+      - name: Test (race)
+        if: runner.os == 'Linux'
+        run: go test -race ./...
+
+  staticcheck:
+    name: staticcheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          check-latest: true
+
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@2025.1.1
+
+      - name: Run staticcheck
+        run: staticcheck ./...
+
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          check-latest: true
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+
+      - name: Run govulncheck
+        run: govulncheck ./...


### PR DESCRIPTION
Closes #8

Adds CI scaffolding for the repo:

- `.github/workflows/ci.yml`:
  - `test` job: matrix over ubuntu/macos/windows on Go 1.25 (matches go.mod). Runs `go build`, `go vet`, `go test -coverprofile=coverage.out`. A separate Linux-only step adds `go test -race` (Windows + mingw is flaky for race detector).
  - `staticcheck` job (Linux, Go 1.25). Version pinned for reproducibility.
  - `govulncheck` job (Linux, Go 1.25). Version pinned.
- `.github/dependabot.yml`: weekly gomod + github-actions updates.

**Acceptance**
- [x] Workflows parse cleanly
- [x] Dependabot config covers gomod + github-actions
- [x] govulncheck failures break the build (non-zero exit)
- [ ] Branch protection enforcement — admin task, separate

**Pair-programming flow**
- Implementer: Driver agent
- Reviewer: Navigator agent
- Round 2 revisions: dropped Go 1.24 from matrix (go.mod requires 1.25.0), separated `-race` to Linux-only, pinned govulncheck and staticcheck versions.