### PR TITLE
Plumb context.Context through every networked method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Note: pre-1.0 releases may break the API at any minor bump.
+
+## [Unreleased]
+
+### Changed
+- **BREAKING:** Every networked method on `*Client` and `*Importer` now takes
+  `ctx context.Context` as the first parameter (#2). Existing callers must
+  update their call sites.
+- **BREAKING:** The `Client.ReAuth` callback signature changed from
+  `func() error` to `func(context.Context) error` (#2).
+
+## [0.1.0] - TBD
+
+- Initial extraction from emersion/hydroxide.

--- a/addresses.go
+++ b/addresses.go
@@ -1,6 +1,7 @@
 package protonmail
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -42,9 +43,9 @@ type Address struct {
 	Keys        []*PrivateKey
 }
 
-func (c *Client) ListAddresses() ([]*Address, error) {
+func (c *Client) ListAddresses(ctx context.Context) ([]*Address, error) {
 	// TODO: Page, PageSize
-	req, err := c.newRequest(http.MethodGet, "/addresses", nil)
+	req, err := c.newRequest(ctx, http.MethodGet, "/addresses", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +54,7 @@ func (c *Client) ListAddresses() ([]*Address, error) {
 		resp
 		Addresses []*Address
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, err
 	}
 

--- a/attachments.go
+++ b/attachments.go
@@ -2,6 +2,7 @@ package protonmail
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -107,13 +108,13 @@ func (att *Attachment) Read(ciphertext io.Reader, keyring openpgp.KeyRing, promp
 
 // GetAttachment downloads an attachment's payload. The returned io.ReadCloser
 // may be encrypted, use Attachment.Read to decrypt it.
-func (c *Client) GetAttachment(id string) (io.ReadCloser, error) {
-	req, err := c.newRequest(http.MethodGet, "/attachments/"+id, nil)
+func (c *Client) GetAttachment(ctx context.Context, id string) (io.ReadCloser, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, "/attachments/"+id, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.do(req)
+	resp, err := c.do(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +128,7 @@ func (c *Client) GetAttachment(id string) (io.ReadCloser, error) {
 
 // CreateAttachment uploads a new attachment. r must be an PGP data packet
 // encrypted with att.KeyPackets.
-func (c *Client) CreateAttachment(att *Attachment, r io.Reader) (created *Attachment, err error) {
+func (c *Client) CreateAttachment(ctx context.Context, att *Attachment, r io.Reader) (created *Attachment, err error) {
 	pr, pw := io.Pipe()
 	mw := multipart.NewWriter(pw)
 
@@ -178,7 +179,7 @@ func (c *Client) CreateAttachment(att *Attachment, r io.Reader) (created *Attach
 		pw.CloseWithError(mw.Close())
 	}()
 
-	req, err := c.newRequest(http.MethodPost, "/attachments", pr)
+	req, err := c.newRequest(ctx, http.MethodPost, "/attachments", pr)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +190,7 @@ func (c *Client) CreateAttachment(att *Attachment, r io.Reader) (created *Attach
 		resp
 		Attachment *Attachment
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, err
 	}
 

--- a/auth.go
+++ b/auth.go
@@ -2,6 +2,7 @@ package protonmail
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -47,18 +48,18 @@ func (resp *AuthInfoResp) authInfo() *AuthInfo {
 	return info
 }
 
-func (c *Client) AuthInfo(username string) (*AuthInfo, error) {
+func (c *Client) AuthInfo(ctx context.Context, username string) (*AuthInfo, error) {
 	reqData := &authInfoReq{
 		Username: username,
 	}
 
-	req, err := c.newJSONRequest(http.MethodPost, "/auth/info", reqData)
+	req, err := c.newJSONRequest(ctx, http.MethodPost, "/auth/info", reqData)
 	if err != nil {
 		return nil, err
 	}
 
 	var respData AuthInfoResp
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, err
 	}
 
@@ -109,10 +110,10 @@ func (resp *authResp) auth() *Auth {
 	return auth
 }
 
-func (c *Client) Auth(username, password string, info *AuthInfo) (*Auth, error) {
+func (c *Client) Auth(ctx context.Context, username, password string, info *AuthInfo) (*Auth, error) {
 	if info == nil {
 		var err error
-		if info, err = c.AuthInfo(username); err != nil {
+		if info, err = c.AuthInfo(ctx, username); err != nil {
 			return nil, err
 		}
 	}
@@ -129,13 +130,13 @@ func (c *Client) Auth(username, password string, info *AuthInfo) (*Auth, error) 
 		ClientProof:     base64.StdEncoding.EncodeToString(proofs.clientProof),
 	}
 
-	req, err := c.newJSONRequest(http.MethodPost, "/auth", reqData)
+	req, err := c.newJSONRequest(ctx, http.MethodPost, "/auth", reqData)
 	if err != nil {
 		return nil, err
 	}
 
 	var respData authResp
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, err
 	}
 
@@ -149,14 +150,14 @@ func (c *Client) Auth(username, password string, info *AuthInfo) (*Auth, error) 
 	return auth, nil
 }
 
-func (c *Client) AuthTOTP(code string) (scope string, err error) {
+func (c *Client) AuthTOTP(ctx context.Context, code string) (scope string, err error) {
 	reqData := struct {
 		TwoFactorCode string
 	}{
 		TwoFactorCode: code,
 	}
 
-	req, err := c.newJSONRequest(http.MethodPost, "/auth/2fa", reqData)
+	req, err := c.newJSONRequest(ctx, http.MethodPost, "/auth/2fa", reqData)
 	if err != nil {
 		return "", err
 	}
@@ -165,7 +166,7 @@ func (c *Client) AuthTOTP(code string) (scope string, err error) {
 		resp
 		Scope string
 	}{}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return "", err
 	}
 
@@ -181,7 +182,7 @@ type authRefreshReq struct {
 	RedirectURI  string
 }
 
-func (c *Client) AuthRefresh(expiredAuth *Auth) (*Auth, error) {
+func (c *Client) AuthRefresh(ctx context.Context, expiredAuth *Auth) (*Auth, error) {
 	reqData := &authRefreshReq{
 		RefreshToken: expiredAuth.RefreshToken,
 		ResponseType: "token",
@@ -189,14 +190,14 @@ func (c *Client) AuthRefresh(expiredAuth *Auth) (*Auth, error) {
 		RedirectURI:  "http://www.protonmail.ch",
 	}
 
-	req, err := c.newJSONRequest(http.MethodPost, "/auth/refresh", reqData)
+	req, err := c.newJSONRequest(ctx, http.MethodPost, "/auth/refresh", reqData)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("X-Pm-Uid", expiredAuth.UID)
 
 	var respData authResp
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, err
 	}
 
@@ -206,8 +207,8 @@ func (c *Client) AuthRefresh(expiredAuth *Auth) (*Auth, error) {
 	return auth, nil
 }
 
-func (c *Client) ListKeySalts() (map[string][]byte, error) {
-	req, err := c.newRequest(http.MethodGet, "/keys/salts", nil)
+func (c *Client) ListKeySalts(ctx context.Context) (map[string][]byte, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, "/keys/salts", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +220,7 @@ func (c *Client) ListKeySalts() (map[string][]byte, error) {
 			KeySalt string
 		}
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, err
 	}
 
@@ -328,11 +329,11 @@ func unlockKeyRing(keys []*PrivateKey, userKeyRing openpgp.EntityList, keySalts 
 	return keyRing, nil
 }
 
-func (c *Client) Unlock(auth *Auth, keySalts map[string][]byte, passphrase string) (openpgp.EntityList, error) {
+func (c *Client) Unlock(ctx context.Context, auth *Auth, keySalts map[string][]byte, passphrase string) (openpgp.EntityList, error) {
 	c.uid = auth.UID
 	c.accessToken = auth.AccessToken
 
-	u, err := c.GetCurrentUser()
+	u, err := c.GetCurrentUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -342,7 +343,7 @@ func (c *Client) Unlock(auth *Auth, keySalts map[string][]byte, passphrase strin
 		return nil, err
 	}
 
-	addrs, err := c.ListAddresses()
+	addrs, err := c.ListAddresses(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -367,13 +368,13 @@ func (c *Client) Unlock(auth *Auth, keySalts map[string][]byte, passphrase strin
 	return keyRing, nil
 }
 
-func (c *Client) Logout() error {
-	req, err := c.newRequest(http.MethodDelete, "/auth", nil)
+func (c *Client) Logout(ctx context.Context) error {
+	req, err := c.newRequest(ctx, http.MethodDelete, "/auth", nil)
 	if err != nil {
 		return err
 	}
 
-	if err := c.doJSON(req, nil); err != nil {
+	if err := c.doJSON(ctx, req, nil); err != nil {
 		return err
 	}
 

--- a/calendar.go
+++ b/calendar.go
@@ -1,6 +1,7 @@
 package protonmail
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -44,14 +45,14 @@ type CalendarEventCard struct {
 	MemberID  string
 }
 
-func (c *Client) ListCalendars(page, pageSize int) ([]*Calendar, error) {
+func (c *Client) ListCalendars(ctx context.Context, page, pageSize int) ([]*Calendar, error) {
 	v := url.Values{}
 	v.Set("Page", strconv.Itoa(page))
 	if pageSize > 0 {
 		v.Set("PageSize", strconv.Itoa(pageSize))
 	}
 
-	req, err := c.newRequest(http.MethodGet, calendarPath+"?"+v.Encode(), nil)
+	req, err := c.newRequest(ctx, http.MethodGet, calendarPath+"?"+v.Encode(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +61,7 @@ func (c *Client) ListCalendars(page, pageSize int) ([]*Calendar, error) {
 		resp
 		Calendars []*Calendar
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, err
 	}
 
@@ -73,7 +74,7 @@ type CalendarEventFilter struct {
 	Page, PageSize int
 }
 
-func (c *Client) ListCalendarEvents(calendarID string, filter *CalendarEventFilter) ([]*CalendarEvent, error) {
+func (c *Client) ListCalendarEvents(ctx context.Context, calendarID string, filter *CalendarEventFilter) ([]*CalendarEvent, error) {
 	v := url.Values{}
 	v.Set("Start", strconv.FormatInt(filter.Start, 10))
 	v.Set("End", strconv.FormatInt(filter.End, 10))
@@ -83,7 +84,7 @@ func (c *Client) ListCalendarEvents(calendarID string, filter *CalendarEventFilt
 		v.Set("PageSize", strconv.Itoa(filter.PageSize))
 	}
 
-	req, err := c.newRequest(http.MethodGet, calendarPath+"/"+calendarID+"/events?"+v.Encode(), nil)
+	req, err := c.newRequest(ctx, http.MethodGet, calendarPath+"/"+calendarID+"/events?"+v.Encode(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +93,7 @@ func (c *Client) ListCalendarEvents(calendarID string, filter *CalendarEventFilt
 		resp
 		Events []*CalendarEvent
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, err
 	}
 

--- a/contacts.go
+++ b/contacts.go
@@ -2,6 +2,7 @@ package protonmail
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -219,14 +220,14 @@ type ContactImport struct {
 	Cards []*ContactCard
 }
 
-func (c *Client) ListContacts(page, pageSize int) (total int, contacts []*Contact, err error) {
+func (c *Client) ListContacts(ctx context.Context, page, pageSize int) (total int, contacts []*Contact, err error) {
 	v := url.Values{}
 	v.Set("Page", strconv.Itoa(page))
 	if pageSize > 0 {
 		v.Set("PageSize", strconv.Itoa(pageSize))
 	}
 
-	req, err := c.newRequest(http.MethodGet, "/contacts?"+v.Encode(), nil)
+	req, err := c.newRequest(ctx, http.MethodGet, "/contacts?"+v.Encode(), nil)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -236,21 +237,21 @@ func (c *Client) ListContacts(page, pageSize int) (total int, contacts []*Contac
 		Contacts []*Contact
 		Total    int
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return 0, nil, err
 	}
 
 	return respData.Total, respData.Contacts, nil
 }
 
-func (c *Client) ListContactsEmails(page, pageSize int) (total int, emails []*ContactEmail, err error) {
+func (c *Client) ListContactsEmails(ctx context.Context, page, pageSize int) (total int, emails []*ContactEmail, err error) {
 	v := url.Values{}
 	v.Set("Page", strconv.Itoa(page))
 	if pageSize > 0 {
 		v.Set("PageSize", strconv.Itoa(pageSize))
 	}
 
-	req, err := c.newRequest(http.MethodGet, "/contacts/emails?"+v.Encode(), nil)
+	req, err := c.newRequest(ctx, http.MethodGet, "/contacts/emails?"+v.Encode(), nil)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -260,21 +261,21 @@ func (c *Client) ListContactsEmails(page, pageSize int) (total int, emails []*Co
 		ContactEmails []*ContactEmail
 		Total         int
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return 0, nil, err
 	}
 
 	return respData.Total, respData.ContactEmails, nil
 }
 
-func (c *Client) ListContactsExport(page, pageSize int) (total int, contacts []*ContactExport, err error) {
+func (c *Client) ListContactsExport(ctx context.Context, page, pageSize int) (total int, contacts []*ContactExport, err error) {
 	v := url.Values{}
 	v.Set("Page", strconv.Itoa(page))
 	if pageSize > 0 {
 		v.Set("PageSize", strconv.Itoa(pageSize))
 	}
 
-	req, err := c.newRequest(http.MethodGet, "/contacts/export?"+v.Encode(), nil)
+	req, err := c.newRequest(ctx, http.MethodGet, "/contacts/export?"+v.Encode(), nil)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -284,15 +285,15 @@ func (c *Client) ListContactsExport(page, pageSize int) (total int, contacts []*
 		Contacts []*ContactExport
 		Total    int
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return 0, nil, err
 	}
 
 	return respData.Total, respData.Contacts, nil
 }
 
-func (c *Client) GetContact(id string) (*Contact, error) {
-	req, err := c.newRequest(http.MethodGet, "/contacts/"+id, nil)
+func (c *Client) GetContact(ctx context.Context, id string) (*Contact, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, "/contacts/"+id, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -301,7 +302,7 @@ func (c *Client) GetContact(id string) (*Contact, error) {
 		resp
 		Contact *Contact
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, err
 	}
 
@@ -320,12 +321,12 @@ func (resp *CreateContactResp) Err() error {
 	return resp.Response.Err()
 }
 
-func (c *Client) CreateContacts(contacts []*ContactImport) ([]*CreateContactResp, error) {
+func (c *Client) CreateContacts(ctx context.Context, contacts []*ContactImport) ([]*CreateContactResp, error) {
 	reqData := struct {
 		Contacts                  []*ContactImport
 		Overwrite, Groups, Labels int
 	}{contacts, 0, 0, 0}
-	req, err := c.newJSONRequest(http.MethodPost, "/contacts", &reqData)
+	req, err := c.newJSONRequest(ctx, http.MethodPost, "/contacts", &reqData)
 	if err != nil {
 		return nil, err
 	}
@@ -334,15 +335,15 @@ func (c *Client) CreateContacts(contacts []*ContactImport) ([]*CreateContactResp
 		resp
 		Responses []*CreateContactResp
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, err
 	}
 
 	return respData.Responses, nil
 }
 
-func (c *Client) UpdateContact(id string, contact *ContactImport) (*Contact, error) {
-	req, err := c.newJSONRequest(http.MethodPut, "/contacts/"+id, contact)
+func (c *Client) UpdateContact(ctx context.Context, id string, contact *ContactImport) (*Contact, error) {
+	req, err := c.newJSONRequest(ctx, http.MethodPut, "/contacts/"+id, contact)
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +352,7 @@ func (c *Client) UpdateContact(id string, contact *ContactImport) (*Contact, err
 		resp
 		Contact *Contact
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, err
 	}
 
@@ -369,11 +370,11 @@ func (resp *DeleteContactResp) Err() error {
 	return resp.Response.Err()
 }
 
-func (c *Client) DeleteContacts(ids []string) ([]*DeleteContactResp, error) {
+func (c *Client) DeleteContacts(ctx context.Context, ids []string) ([]*DeleteContactResp, error) {
 	reqData := struct {
 		IDs []string
 	}{ids}
-	req, err := c.newJSONRequest(http.MethodPut, "/contacts/delete", &reqData)
+	req, err := c.newJSONRequest(ctx, http.MethodPut, "/contacts/delete", &reqData)
 	if err != nil {
 		return nil, err
 	}
@@ -382,21 +383,21 @@ func (c *Client) DeleteContacts(ids []string) ([]*DeleteContactResp, error) {
 		resp
 		Responses []*DeleteContactResp
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, err
 	}
 
 	return respData.Responses, nil
 }
 
-func (c *Client) DeleteAllContacts() error {
-	req, err := c.newRequest(http.MethodDelete, "/contacts", nil)
+func (c *Client) DeleteAllContacts(ctx context.Context) error {
+	req, err := c.newRequest(ctx, http.MethodDelete, "/contacts", nil)
 	if err != nil {
 		return err
 	}
 
 	var respData resp
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return err
 	}
 

--- a/conversations.go
+++ b/conversations.go
@@ -1,6 +1,7 @@
 package protonmail
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 )
@@ -20,13 +21,13 @@ type Conversation struct {
 	LabelIDs       []string
 }
 
-func (c *Client) GetConversation(id, msgID string) (*Conversation, []*Message, error) {
+func (c *Client) GetConversation(ctx context.Context, id, msgID string) (*Conversation, []*Message, error) {
 	v := url.Values{}
 	if msgID != "" {
 		v.Set("MessageID", msgID)
 	}
 
-	req, err := c.newRequest(http.MethodGet, "/conversations/"+id+"?"+v.Encode(), nil)
+	req, err := c.newRequest(ctx, http.MethodGet, "/conversations/"+id+"?"+v.Encode(), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -36,7 +37,7 @@ func (c *Client) GetConversation(id, msgID string) (*Conversation, []*Message, e
 		Conversation *Conversation
 		Messages     []*Message
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, nil, err
 	}
 

--- a/events.go
+++ b/events.go
@@ -1,6 +1,7 @@
 package protonmail
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 )
@@ -160,12 +161,12 @@ type EventContact struct {
 	Contact *Contact
 }
 
-func (c *Client) GetEvent(last string) (*Event, error) {
+func (c *Client) GetEvent(ctx context.Context, last string) (*Event, error) {
 	if last == "" {
 		last = "latest"
 	}
 
-	req, err := c.newRequest(http.MethodGet, "/events/"+last, nil)
+	req, err := c.newRequest(ctx, http.MethodGet, "/events/"+last, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +175,7 @@ func (c *Client) GetEvent(last string) (*Event, error) {
 		resp
 		*Event
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, err
 	}
 

--- a/import.go
+++ b/import.go
@@ -1,6 +1,7 @@
 package protonmail
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -35,7 +36,7 @@ type Importer struct {
 	result   <-chan ImportResult
 }
 
-func (imp *Importer) ImportMessage(key string) (io.Writer, error) {
+func (imp *Importer) ImportMessage(ctx context.Context, key string) (io.Writer, error) {
 	if uploaded, ok := imp.uploaded[key]; !ok {
 		return nil, fmt.Errorf("protonmail: unknown import message %q", key)
 	} else if uploaded {
@@ -66,7 +67,7 @@ func (imp *Importer) close() error {
 	return imp.pw.Close()
 }
 
-func (imp *Importer) Commit() (ImportResult, error) {
+func (imp *Importer) Commit(ctx context.Context) (ImportResult, error) {
 	if err := imp.close(); err != nil {
 		return nil, err
 	}
@@ -84,7 +85,7 @@ func (imp *Importer) Commit() (ImportResult, error) {
 	return <-imp.result, nil
 }
 
-func (c *Client) Import(metadata map[string]*Message) (*Importer, error) {
+func (c *Client) Import(ctx context.Context, metadata map[string]*Message) (*Importer, error) {
 	pr, pw := io.Pipe()
 
 	mw := multipart.NewWriter(pw)
@@ -95,7 +96,7 @@ func (c *Client) Import(metadata map[string]*Message) (*Importer, error) {
 		defer close(done)
 		defer close(result)
 
-		req, err := c.newRequest(http.MethodPost, "/import", pr)
+		req, err := c.newRequest(ctx, http.MethodPost, "/import", pr)
 		if err != nil {
 			done <- err
 			return
@@ -113,7 +114,7 @@ func (c *Client) Import(metadata map[string]*Message) (*Importer, error) {
 			resp
 			Responses []messageResp
 		}
-		err = c.doJSON(req, &respData)
+		err = c.doJSON(ctx, req, &respData)
 		done <- err
 		if err != nil {
 			return

--- a/keys.go
+++ b/keys.go
@@ -1,6 +1,7 @@
 package protonmail
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -71,12 +72,12 @@ func (pub *PublicKey) Entity() (*openpgp.Entity, error) {
 }
 
 // GetPublicKeys retrieves public keys for a user.
-func (c *Client) GetPublicKeys(email string) (*PublicKeyResp, error) {
+func (c *Client) GetPublicKeys(ctx context.Context, email string) (*PublicKeyResp, error) {
 	v := url.Values{}
 	v.Set("Email", email)
 	// TODO: Fingerprint
 
-	req, err := c.newRequest(http.MethodGet, "/keys?"+v.Encode(), nil)
+	req, err := c.newRequest(ctx, http.MethodGet, "/keys?"+v.Encode(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +86,7 @@ func (c *Client) GetPublicKeys(email string) (*PublicKeyResp, error) {
 		resp
 		*PublicKeyResp
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, err
 	}
 

--- a/labels.go
+++ b/labels.go
@@ -1,6 +1,7 @@
 package protonmail
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -35,8 +36,8 @@ type Label struct {
 	Order     int
 }
 
-func (c *Client) ListLabels() ([]*Label, error) {
-	req, err := c.newRequest(http.MethodGet, "/labels", nil)
+func (c *Client) ListLabels(ctx context.Context) ([]*Label, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, "/labels", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +46,7 @@ func (c *Client) ListLabels() ([]*Label, error) {
 		resp
 		Labels []*Label
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, err
 	}
 

--- a/messages.go
+++ b/messages.go
@@ -2,6 +2,7 @@ package protonmail
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"errors"
 	"io"
@@ -166,7 +167,7 @@ type MessageFilter struct {
 	ExternalID   string
 }
 
-func (c *Client) ListMessages(filter *MessageFilter) (total int, messages []*Message, err error) {
+func (c *Client) ListMessages(ctx context.Context, filter *MessageFilter) (total int, messages []*Message, err error) {
 	v := url.Values{}
 	if filter.Page != 0 {
 		v.Set("Page", strconv.Itoa(filter.Page))
@@ -196,7 +197,7 @@ func (c *Client) ListMessages(filter *MessageFilter) (total int, messages []*Mes
 		v.Set("ExternalID", filter.ExternalID)
 	}
 
-	req, err := c.newRequest(http.MethodGet, "/messages?"+v.Encode(), nil)
+	req, err := c.newRequest(ctx, http.MethodGet, "/messages?"+v.Encode(), nil)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -206,7 +207,7 @@ func (c *Client) ListMessages(filter *MessageFilter) (total int, messages []*Mes
 		Total    int
 		Messages []*Message
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return 0, nil, err
 	}
 
@@ -219,12 +220,12 @@ type MessageCount struct {
 	Unread  int
 }
 
-func (c *Client) CountMessages(address string) ([]*MessageCount, error) {
+func (c *Client) CountMessages(ctx context.Context, address string) ([]*MessageCount, error) {
 	v := url.Values{}
 	if address != "" {
 		v.Set("Address", address)
 	}
-	req, err := c.newRequest(http.MethodGet, "/messages/count?"+v.Encode(), nil)
+	req, err := c.newRequest(ctx, http.MethodGet, "/messages/count?"+v.Encode(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -233,15 +234,15 @@ func (c *Client) CountMessages(address string) ([]*MessageCount, error) {
 		resp
 		Counts []*MessageCount
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, err
 	}
 
 	return respData.Counts, nil
 }
 
-func (c *Client) GetMessage(id string) (*Message, error) {
-	req, err := c.newRequest(http.MethodGet, "/messages/"+id, nil)
+func (c *Client) GetMessage(ctx context.Context, id string) (*Message, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, "/messages/"+id, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +251,7 @@ func (c *Client) GetMessage(id string) (*Message, error) {
 		resp
 		Message *Message
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, err
 	}
 
@@ -259,7 +260,7 @@ func (c *Client) GetMessage(id string) (*Message, error) {
 
 // CreateDraftMessage creates a new draft message. ToList, CCList, BCCList,
 // Subject, Body and AddressID are required in msg.
-func (c *Client) CreateDraftMessage(msg *Message, parentID string) (*Message, error) {
+func (c *Client) CreateDraftMessage(ctx context.Context, msg *Message, parentID string) (*Message, error) {
 	var actionPtr *MessageAction
 	if parentID != "" {
 		// TODO: support other actions
@@ -272,7 +273,7 @@ func (c *Client) CreateDraftMessage(msg *Message, parentID string) (*Message, er
 		ParentID string         `json:",omitempty"`
 		Action   *MessageAction `json:",omitempty"`
 	}{msg, parentID, actionPtr}
-	req, err := c.newJSONRequest(http.MethodPost, "/messages", &reqData)
+	req, err := c.newJSONRequest(ctx, http.MethodPost, "/messages", &reqData)
 	if err != nil {
 		return nil, err
 	}
@@ -281,18 +282,18 @@ func (c *Client) CreateDraftMessage(msg *Message, parentID string) (*Message, er
 		resp
 		Message *Message
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, err
 	}
 
 	return respData.Message, nil
 }
 
-func (c *Client) UpdateDraftMessage(msg *Message) (*Message, error) {
+func (c *Client) UpdateDraftMessage(ctx context.Context, msg *Message) (*Message, error) {
 	reqData := struct {
 		Message *Message
 	}{msg}
-	req, err := c.newJSONRequest(http.MethodPut, "/messages/"+msg.ID, &reqData)
+	req, err := c.newJSONRequest(ctx, http.MethodPut, "/messages/"+msg.ID, &reqData)
 	if err != nil {
 		return nil, err
 	}
@@ -301,68 +302,68 @@ func (c *Client) UpdateDraftMessage(msg *Message) (*Message, error) {
 		resp
 		Message *Message
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, err
 	}
 
 	return respData.Message, nil
 }
 
-func (c *Client) doMessages(action string, ids []string) error {
+func (c *Client) doMessages(ctx context.Context, action string, ids []string) error {
 	reqData := struct {
 		IDs []string
 	}{ids}
-	req, err := c.newJSONRequest(http.MethodPut, "/messages/"+action, &reqData)
+	req, err := c.newJSONRequest(ctx, http.MethodPut, "/messages/"+action, &reqData)
 	if err != nil {
 		return err
 	}
 
 	// TODO: the response contains one response per message
-	return c.doJSON(req, nil)
+	return c.doJSON(ctx, req, nil)
 }
 
-func (c *Client) MarkMessagesRead(ids []string) error {
-	return c.doMessages("read", ids)
+func (c *Client) MarkMessagesRead(ctx context.Context, ids []string) error {
+	return c.doMessages(ctx, "read", ids)
 }
 
-func (c *Client) MarkMessagesUnread(ids []string) error {
-	return c.doMessages("unread", ids)
+func (c *Client) MarkMessagesUnread(ctx context.Context, ids []string) error {
+	return c.doMessages(ctx, "unread", ids)
 }
 
-func (c *Client) DeleteMessages(ids []string) error {
-	return c.doMessages("delete", ids)
+func (c *Client) DeleteMessages(ctx context.Context, ids []string) error {
+	return c.doMessages(ctx, "delete", ids)
 }
 
-func (c *Client) UndeleteMessages(ids []string) error {
-	return c.doMessages("undelete", ids)
+func (c *Client) UndeleteMessages(ctx context.Context, ids []string) error {
+	return c.doMessages(ctx, "undelete", ids)
 }
 
-func (c *Client) LabelMessages(labelID string, ids []string) error {
+func (c *Client) LabelMessages(ctx context.Context, labelID string, ids []string) error {
 	reqData := struct {
 		LabelID string
 		IDs     []string
 	}{labelID, ids}
-	req, err := c.newJSONRequest(http.MethodPut, "/messages/label", &reqData)
+	req, err := c.newJSONRequest(ctx, http.MethodPut, "/messages/label", &reqData)
 	if err != nil {
 		return err
 	}
 
 	// TODO: the response contains one response per message
-	return c.doJSON(req, nil)
+	return c.doJSON(ctx, req, nil)
 }
 
-func (c *Client) UnlabelMessages(labelID string, ids []string) error {
+func (c *Client) UnlabelMessages(ctx context.Context, labelID string, ids []string) error {
 	reqData := struct {
 		LabelID string
 		IDs     []string
 	}{labelID, ids}
-	req, err := c.newJSONRequest(http.MethodPut, "/messages/unlabel", &reqData)
+	req, err := c.newJSONRequest(ctx, http.MethodPut, "/messages/unlabel", &reqData)
 	if err != nil {
 		return err
 	}
 
 	// TODO: the response contains one response per message
-	return c.doJSON(req, nil)
+	return c.doJSON(ctx, req, nil)
 }
 
 type MessageKeyPacket struct {
@@ -581,8 +582,8 @@ type OutgoingMessage struct {
 	Packages []*MessagePackageSet
 }
 
-func (c *Client) SendMessage(msg *OutgoingMessage) (sent, parent *Message, err error) {
-	req, err := c.newJSONRequest(http.MethodPost, "/messages/"+msg.ID, msg)
+func (c *Client) SendMessage(ctx context.Context, msg *OutgoingMessage) (sent, parent *Message, err error) {
+	req, err := c.newJSONRequest(ctx, http.MethodPost, "/messages/"+msg.ID, msg)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -591,7 +592,7 @@ func (c *Client) SendMessage(msg *OutgoingMessage) (sent, parent *Message, err e
 		resp
 		Sent, Parent *Message
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, nil, err
 	}
 

--- a/protonmail.go
+++ b/protonmail.go
@@ -3,6 +3,7 @@ package protonmail
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -64,7 +65,7 @@ type Client struct {
 	Debug      bool
 
 	HTTPClient *http.Client
-	ReAuth     func() error
+	ReAuth     func(ctx context.Context) error
 
 	uid         string
 	accessToken string
@@ -78,8 +79,8 @@ func (c *Client) setRequestAuthorization(req *http.Request) {
 	}
 }
 
-func (c *Client) newRequest(method, path string, body io.Reader) (*http.Request, error) {
-	req, err := http.NewRequest(method, c.RootURL+path, body)
+func (c *Client) newRequest(ctx context.Context, method, path string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.RootURL+path, body)
 	if err != nil {
 		return nil, err
 	}
@@ -94,14 +95,14 @@ func (c *Client) newRequest(method, path string, body io.Reader) (*http.Request,
 	return req, nil
 }
 
-func (c *Client) newJSONRequest(method, path string, body interface{}) (*http.Request, error) {
+func (c *Client) newJSONRequest(ctx context.Context, method, path string, body interface{}) (*http.Request, error) {
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(body); err != nil {
 		return nil, err
 	}
 	b := buf.Bytes()
 
-	req, err := c.newRequest(method, path, bytes.NewReader(b))
+	req, err := c.newRequest(ctx, method, path, bytes.NewReader(b))
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +118,7 @@ func (c *Client) newJSONRequest(method, path string, body interface{}) (*http.Re
 	return req, nil
 }
 
-func (c *Client) do(req *http.Request) (*http.Response, error) {
+func (c *Client) do(ctx context.Context, req *http.Request) (*http.Response, error) {
 	req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:101.0) Gecko/20100101 Firefox/101.0")
 
 	httpClient := c.HTTPClient
@@ -136,7 +137,7 @@ func (c *Client) do(req *http.Request) (*http.Response, error) {
 	if resp.StatusCode == http.StatusUnauthorized && hasAuth && c.ReAuth != nil && canRetry {
 		resp.Body.Close()
 		c.accessToken = ""
-		if err := c.ReAuth(); err != nil {
+		if err := c.ReAuth(ctx); err != nil {
 			return resp, err
 		}
 		c.setRequestAuthorization(req) // Access token has changed
@@ -147,20 +148,20 @@ func (c *Client) do(req *http.Request) (*http.Response, error) {
 			}
 			req.Body = body
 		}
-		return c.do(req)
+		return c.do(ctx, req)
 	}
 
 	return resp, nil
 }
 
-func (c *Client) doJSON(req *http.Request, respData interface{}) error {
+func (c *Client) doJSON(ctx context.Context, req *http.Request, respData interface{}) error {
 	req.Header.Set("Accept", "application/json")
 
 	if respData == nil {
 		respData = new(resp)
 	}
 
-	resp, err := c.do(req)
+	resp, err := c.do(ctx, req)
 	if err != nil {
 		return err
 	}

--- a/users.go
+++ b/users.go
@@ -1,6 +1,7 @@
 package protonmail
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -20,8 +21,8 @@ type User struct {
 	Keys       []*PrivateKey
 }
 
-func (c *Client) GetCurrentUser() (*User, error) {
-	req, err := c.newRequest(http.MethodGet, "/users", nil)
+func (c *Client) GetCurrentUser(ctx context.Context) (*User, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, "/users", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +31,7 @@ func (c *Client) GetCurrentUser() (*User, error) {
 		resp
 		User *User
 	}
-	if err := c.doJSON(req, &respData); err != nil {
+	if err := c.doJSON(ctx, req, &respData); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Closes #2

**BREAKING:** Adds `ctx context.Context` as the first parameter to every networked method on `*Client` and `*Importer`. The `Client.ReAuth` callback also changes from `func() error` to `func(context.Context) error`.

### What changed
- Internal helpers: `newRequest`, `newJSONRequest`, `do`, `doJSON` all take ctx as first arg. `http.NewRequestWithContext` is the only request constructor used.
- ~40 exported methods on `*Client` and 2 on `*Importer` updated.
- `ReAuth` callback signature updated; the recursive 401 retry passes the same ctx into `ReAuth(ctx)` and the recursive `do(ctx, req)`.
- `CHANGELOG.md` added (keep-a-changelog format) with two BREAKING entries.

### Acceptance
- [x] Every exported HTTP method takes `ctx` as first arg
- [x] `http.NewRequestWithContext` used throughout (no bare `http.NewRequest` remains)
- [x] `go build ./...` and `go vet ./...` clean
- [x] `staticcheck SA1029` clean (manual audit; tool not installed locally)
- [x] CHANGELOG entry present

### Known follow-ups (not blockers)
- `Importer.Commit(ctx)` and `Importer.ImportMessage(ctx, key)` accept ctx but don't `select` on `ctx.Done()` for the blocking channel reads. Cancellation works via the construction-time ctx captured by the goroutine; passing a different ctx at Commit time would not interrupt mid-flight. Worth a small follow-up issue.

### Pair-programming flow
- Implementer: Driver agent
- Reviewer: Navigator agent (verdict: APPROVE)