### PR TITLE
Wrap errors with %w; add typed errors and sentinels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,22 @@ Note: pre-1.0 releases may break the API at any minor bump.
   (`protonmail-go/<version>`) instead of impersonating Firefox (#5, #D5).
 - Improved: `do` now consistently closes the response body on all error
   paths and returns `(nil, err)` on transport errors (#4).
+- **BREAKING:** `APIError`'s `Error()` and field accessors may have changed;
+  the type now implements `Is(target error) bool` (#3).
+- Errors returned from networked methods now wrap their cause with `%w`. Use
+  `errors.Is`/`errors.As` (#3).
+- **BREAKING:** Some errors that were string-formatted are now typed:
+  `*HTTPError` for non-2xx HTTP failures (#3).
+- New sentinels exported: `ErrUnauthorized`, `ErrNotFound`, `ErrRateLimited`,
+  `ErrNoUnlockableKeys`, `ErrImporterClosed` (#3).
+- `*APIError` now carries an optional `HTTPError *HTTPError` field and exposes
+  `Unwrap()` so `errors.Is(err, ErrRateLimited)` / `ErrNotFound` resolve via
+  HTTP status when Proton's application "Code" is unknown. Proton "Code" is
+  treated as a hint; HTTP status is the source of truth (#3).
+- `(*APIError).Error()` and `(*HTTPError).Error()` are now nil-safe and return
+  `"<nil>"` instead of panicking on a nil receiver (#3).
+- `HTTPError.Body` is documented as potentially containing sensitive data
+  (tokens, addresses); callers must not log it verbatim (#3).
 
 ### Fixed
 - `doJSON` now checks HTTP status before JSON-decoding (was producing

--- a/attachments.go
+++ b/attachments.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -120,11 +119,16 @@ func (c *Client) GetAttachment(ctx context.Context, id string) (io.ReadCloser, e
 	}
 
 	if resp.StatusCode/100 != 2 {
-		// Drain (capped) and close the body before returning the error so the
+		// Read up to 64KB of the error body for diagnostic context, then drain
+		// (capped) and close the body before returning the error so the
 		// underlying TCP connection can be reused and we don't leak.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
 		drainAndClose(resp.Body)
-		// TODO #3: replace with a typed *HTTPError once issue #3 lands.
-		return nil, fmt.Errorf("cannot get attachment %q: HTTP %d %s", id, resp.StatusCode, resp.Status)
+		return nil, &HTTPError{
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			Body:       body,
+		}
 	}
 
 	return resp.Body, nil

--- a/auth.go
+++ b/auth.go
@@ -120,7 +120,7 @@ func (c *Client) Auth(ctx context.Context, username, password string, info *Auth
 
 	proofs, err := srp([]byte(password), info)
 	if err != nil {
-		return nil, fmt.Errorf("SRP failed during auth: %v", err)
+		return nil, fmt.Errorf("SRP failed during auth: %w", err)
 	}
 
 	reqData := &authReq{
@@ -232,7 +232,7 @@ func (c *Client) ListKeySalts(ctx context.Context) (map[string][]byte, error) {
 		}
 		payload, err := base64.StdEncoding.DecodeString(salt.KeySalt)
 		if err != nil {
-			return nil, fmt.Errorf("failed to decode key salt payload: %v", err)
+			return nil, fmt.Errorf("failed to decode key salt payload: %w", err)
 		}
 		salts[salt.ID] = payload
 	}
@@ -324,7 +324,7 @@ func unlockKeyRing(keys []*PrivateKey, userKeyRing openpgp.EntityList, keySalts 
 	}
 
 	if len(keyRing) == 0 {
-		return nil, fmt.Errorf("failed to unlock any key")
+		return nil, fmt.Errorf("auth: %w", ErrNoUnlockableKeys)
 	}
 	return keyRing, nil
 }
@@ -360,7 +360,7 @@ func (c *Client) Unlock(ctx context.Context, auth *Auth, keySalts map[string][]b
 	}
 
 	if len(keyRing) == 0 {
-		return nil, fmt.Errorf("failed to unlock any key")
+		return nil, fmt.Errorf("auth: %w", ErrNoUnlockableKeys)
 	}
 
 	c.keyRing = keyRing

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,132 @@
+package protonmail
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// Sentinel errors that callers can match with errors.Is.
+//
+// These represent stable categories of failure that are useful to branch on
+// at the call site. Each is wrapped in more specific context where it is
+// returned, so callers should prefer errors.Is(err, ErrX) over equality.
+var (
+	// ErrUnauthorized indicates the request was rejected because the caller
+	// is not authenticated (or the access token has expired and could not be
+	// refreshed). Returned for HTTP 401 and the equivalent Proton API codes.
+	ErrUnauthorized = errors.New("protonmail: unauthorized")
+
+	// ErrNotFound indicates the requested resource does not exist. Returned
+	// for HTTP 404 and the equivalent Proton API codes.
+	ErrNotFound = errors.New("protonmail: not found")
+
+	// ErrRateLimited indicates the caller has exceeded a rate limit. Returned
+	// for HTTP 429 and the equivalent Proton API codes.
+	ErrRateLimited = errors.New("protonmail: rate limited")
+
+	// ErrNoUnlockableKeys indicates none of the user or address keys could be
+	// decrypted with the supplied passphrase. Returned from key-unlock paths.
+	ErrNoUnlockableKeys = errors.New("protonmail: no unlockable keys")
+
+	// ErrImporterClosed indicates an operation was attempted on an Importer
+	// that has already been closed.
+	ErrImporterClosed = errors.New("protonmail: importer closed")
+)
+
+// Proton API "Code" values that map to sentinels. Proton returns its own
+// numeric code on top of the HTTP status — these are the ones we recognise.
+//
+// Note: Proton's documented "application" codes are 4-digit integers carried
+// in the response envelope's "Code" field; they are NOT HTTP status codes.
+// Where we list HTTP status numbers below (e.g. 401), it is a defensive
+// fallback against servers or proxies that put the HTTP status in the
+// envelope code. The source of truth for HTTP-level categorisation
+// (rate-limit, not-found) is *HTTPError, reached via errors.Unwrap.
+const (
+	// apiCodeInvalidCredentials is Proton's documented code for a wrong
+	// username/password combination on the auth endpoints.
+	apiCodeInvalidCredentials = 8002
+
+	// apiCodeAuthRequired is a defensive fallback: some servers/proxies put
+	// the HTTP 401 in the envelope's "Code" instead of (or in addition to)
+	// a Proton 4-digit code. Match on it so users aren't bitten by that.
+	apiCodeAuthRequired = http.StatusUnauthorized
+)
+
+// Is reports whether the APIError matches one of the package sentinels.
+//
+// APIError carries Proton's application-layer "Code" field, which is a hint:
+// the source of truth for HTTP-level categorisation (rate-limited, not-found)
+// is the wrapped *HTTPError, reachable via errors.Unwrap. errors.Is walks the
+// chain, so a caller doing errors.Is(err, ErrRateLimited) will succeed via
+// HTTPError.Is even if APIError.Is does not match.
+//
+// Currently APIError only matches ErrUnauthorized directly, on the documented
+// Proton code 8002 ("invalid credentials") and the defensive HTTP-401 fallback.
+// Other sentinels (ErrNotFound, ErrRateLimited) are left to *HTTPError.
+func (err *APIError) Is(target error) bool {
+	if err == nil || target == nil {
+		return false
+	}
+	if target == ErrUnauthorized {
+		return err.Code == apiCodeInvalidCredentials ||
+			err.Code == apiCodeAuthRequired
+	}
+	return false
+}
+
+// Unwrap returns the underlying *HTTPError, if any. This lets errors.Is and
+// errors.As walk from an APIError to the HTTP-level error so callers can
+// match on HTTP status (e.g. ErrRateLimited via HTTP 429) even when Proton's
+// application "Code" is unknown.
+func (err *APIError) Unwrap() error {
+	if err == nil || err.HTTPError == nil {
+		return nil
+	}
+	return err.HTTPError
+}
+
+// HTTPError represents an HTTP-level failure: a non-2xx response that did not
+// carry a parseable APIError body (or that the caller wants to surface as a
+// raw HTTP failure).
+type HTTPError struct {
+	StatusCode int
+	Status     string
+
+	// Body is the raw response body (truncated to a sane upper bound by the
+	// caller). It MAY contain sensitive data — tokens, email addresses,
+	// nonces, partial PGP material — depending on the endpoint. Do NOT log
+	// Body verbatim; surface it only to the user, in error messages they
+	// have explicitly opted into.
+	Body []byte
+}
+
+// Error implements error. It is nil-safe: calling Error() on a nil receiver
+// returns "<nil>" instead of panicking.
+func (e *HTTPError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Status != "" {
+		return fmt.Sprintf("protonmail: HTTP %s", e.Status)
+	}
+	return fmt.Sprintf("protonmail: HTTP %d", e.StatusCode)
+}
+
+// Is reports whether the HTTPError matches one of the package sentinels,
+// based on the HTTP status code.
+func (e *HTTPError) Is(target error) bool {
+	if e == nil || target == nil {
+		return false
+	}
+	switch target {
+	case ErrUnauthorized:
+		return e.StatusCode == http.StatusUnauthorized
+	case ErrNotFound:
+		return e.StatusCode == http.StatusNotFound
+	case ErrRateLimited:
+		return e.StatusCode == http.StatusTooManyRequests
+	}
+	return false
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,273 @@
+package protonmail
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestAPIError_Is_Unauthorized(t *testing.T) {
+	cases := []struct {
+		name string
+		code int
+		want bool
+	}{
+		{"http 401 fallback", http.StatusUnauthorized, true},
+		{"proton invalid creds 8002", 8002, true},
+		{"proton 1000 success", 1000, false},
+		{"proton 2501 not found", 2501, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := &APIError{Code: tc.code, Message: "denied"}
+			got := errors.Is(err, ErrUnauthorized)
+			if got != tc.want {
+				t.Fatalf("errors.Is(APIError{Code:%d}, ErrUnauthorized) = %v; want %v", tc.code, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAPIError_Is_NotFound_ViaHTTPError verifies that ErrNotFound is matched
+// through the *APIError -> *HTTPError unwrap chain (HTTP 404), not via any
+// guess at a Proton application code.
+func TestAPIError_Is_NotFound_ViaHTTPError(t *testing.T) {
+	err := &APIError{
+		Code:    9999,
+		Message: "missing",
+		HTTPError: &HTTPError{
+			StatusCode: http.StatusNotFound,
+			Status:     "404 Not Found",
+		},
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected APIError wrapping HTTP 404 to match ErrNotFound")
+	}
+
+	// Without an HTTPError, an unknown Proton code does NOT match ErrNotFound.
+	bare := &APIError{Code: 2501, Message: "missing"}
+	if errors.Is(bare, ErrNotFound) {
+		t.Fatalf("APIError.Code=2501 alone (no HTTPError) should not match ErrNotFound")
+	}
+}
+
+// TestAPIError_Is_RateLimited_ViaHTTPError verifies that ErrRateLimited is
+// matched through the unwrap chain (HTTP 429).
+func TestAPIError_Is_RateLimited_ViaHTTPError(t *testing.T) {
+	err := &APIError{
+		Code:    1234,
+		Message: "slow down",
+		HTTPError: &HTTPError{
+			StatusCode: http.StatusTooManyRequests,
+			Status:     "429 Too Many Requests",
+		},
+	}
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("expected APIError wrapping HTTP 429 to match ErrRateLimited")
+	}
+
+	bare := &APIError{Code: 429, Message: "slow"}
+	if errors.Is(bare, ErrRateLimited) {
+		t.Fatalf("APIError.Code=429 alone (no HTTPError) should not match ErrRateLimited")
+	}
+}
+
+// TestAPIError_Unwrap exercises the explicit Unwrap() method.
+func TestAPIError_Unwrap(t *testing.T) {
+	hErr := &HTTPError{StatusCode: 503, Status: "503 Service Unavailable"}
+	err := &APIError{Code: 1, Message: "x", HTTPError: hErr}
+	if errors.Unwrap(err) != hErr {
+		t.Fatalf("APIError.Unwrap() did not return wrapped HTTPError")
+	}
+
+	bare := &APIError{Code: 1, Message: "x"}
+	if errors.Unwrap(bare) != nil {
+		t.Fatalf("APIError.Unwrap() with nil HTTPError should return nil")
+	}
+
+	var nilErr *APIError
+	if errors.Unwrap(nilErr) != nil {
+		t.Fatalf("nil *APIError Unwrap should return nil")
+	}
+}
+
+func TestAPIError_As(t *testing.T) {
+	wrapped := fmt.Errorf("call failed: %w", &APIError{Code: 8002, Message: "bad password"})
+	var apiErr *APIError
+	if !errors.As(wrapped, &apiErr) {
+		t.Fatalf("expected errors.As to extract APIError")
+	}
+	if apiErr.Code != 8002 || apiErr.Message != "bad password" {
+		t.Fatalf("unexpected APIError fields: %+v", apiErr)
+	}
+}
+
+// TestAPIError_AsHTTPError_ThroughChain verifies errors.As can dig through
+// APIError to HTTPError via Unwrap.
+func TestAPIError_AsHTTPError_ThroughChain(t *testing.T) {
+	err := &APIError{
+		Code:      8002,
+		Message:   "bad creds",
+		HTTPError: &HTTPError{StatusCode: 401, Status: "401 Unauthorized", Body: []byte("nope")},
+	}
+	wrapped := fmt.Errorf("auth: %w", err)
+	var hErr *HTTPError
+	if !errors.As(wrapped, &hErr) {
+		t.Fatalf("expected errors.As to extract *HTTPError through APIError")
+	}
+	if hErr.StatusCode != 401 {
+		t.Fatalf("HTTPError.StatusCode = %d, want 401", hErr.StatusCode)
+	}
+}
+
+func TestAPIError_UnwrapsThroughWrapping(t *testing.T) {
+	wrapped := fmt.Errorf("auth: %w", &APIError{Code: 401, Message: "no"})
+	if !errors.Is(wrapped, ErrUnauthorized) {
+		t.Fatalf("expected wrapped APIError(401) to unwrap to ErrUnauthorized")
+	}
+}
+
+func TestHTTPError_Error(t *testing.T) {
+	e := &HTTPError{StatusCode: 503, Status: "503 Service Unavailable"}
+	want := "protonmail: HTTP 503 Service Unavailable"
+	if got := e.Error(); got != want {
+		t.Fatalf("HTTPError.Error() = %q; want %q", got, want)
+	}
+	e2 := &HTTPError{StatusCode: 500}
+	if got := e2.Error(); got != "protonmail: HTTP 500" {
+		t.Fatalf("HTTPError.Error() fallback = %q", got)
+	}
+}
+
+// TestHTTPError_NilReceiver verifies (*HTTPError).Error() does not panic on
+// a nil receiver. Matches the nil-safety of (*HTTPError).Is.
+func TestHTTPError_NilReceiver(t *testing.T) {
+	var e *HTTPError
+	if got := e.Error(); got != "<nil>" {
+		t.Fatalf("nil *HTTPError Error() = %q, want \"<nil>\"", got)
+	}
+	if e.Is(ErrUnauthorized) {
+		t.Fatalf("nil *HTTPError should not match any sentinel")
+	}
+}
+
+func TestHTTPError_Is(t *testing.T) {
+	cases := []struct {
+		status int
+		target error
+		want   bool
+	}{
+		{401, ErrUnauthorized, true},
+		{404, ErrNotFound, true},
+		{429, ErrRateLimited, true},
+		{500, ErrUnauthorized, false},
+		{500, ErrNotFound, false},
+		{500, ErrRateLimited, false},
+	}
+	for _, tc := range cases {
+		e := &HTTPError{StatusCode: tc.status, Status: http.StatusText(tc.status)}
+		if got := errors.Is(e, tc.target); got != tc.want {
+			t.Fatalf("errors.Is(HTTPError{%d}, %v) = %v; want %v", tc.status, tc.target, got, tc.want)
+		}
+	}
+}
+
+func TestHTTPError_AsThroughWrapping(t *testing.T) {
+	src := &HTTPError{StatusCode: 502, Status: "502 Bad Gateway", Body: []byte("oops")}
+	wrapped := fmt.Errorf("attachments: %w", src)
+	var got *HTTPError
+	if !errors.As(wrapped, &got) {
+		t.Fatalf("expected errors.As to extract *HTTPError from wrapped error")
+	}
+	if got.StatusCode != 502 || string(got.Body) != "oops" {
+		t.Fatalf("unexpected HTTPError contents: %+v", got)
+	}
+}
+
+func TestSentinel_ErrNoUnlockableKeys_Unwraps(t *testing.T) {
+	wrapped := fmt.Errorf("auth: %w", ErrNoUnlockableKeys)
+	if !errors.Is(wrapped, ErrNoUnlockableKeys) {
+		t.Fatalf("expected wrapped ErrNoUnlockableKeys to unwrap")
+	}
+}
+
+func TestSentinel_ErrImporterClosed_Identity(t *testing.T) {
+	if !errors.Is(ErrImporterClosed, ErrImporterClosed) {
+		t.Fatalf("ErrImporterClosed should equal itself")
+	}
+	wrapped := fmt.Errorf("commit: %w", ErrImporterClosed)
+	if !errors.Is(wrapped, ErrImporterClosed) {
+		t.Fatalf("expected wrapped ErrImporterClosed to unwrap")
+	}
+}
+
+func TestSentinel_DistinctIdentities(t *testing.T) {
+	if errors.Is(ErrUnauthorized, ErrNotFound) {
+		t.Fatalf("ErrUnauthorized should not match ErrNotFound")
+	}
+	if errors.Is(ErrNoUnlockableKeys, ErrImporterClosed) {
+		t.Fatalf("ErrNoUnlockableKeys should not match ErrImporterClosed")
+	}
+}
+
+func TestAPIError_NilReceiver(t *testing.T) {
+	var err *APIError
+	// Calling Is on nil should not panic and should return false.
+	if err.Is(ErrUnauthorized) {
+		t.Fatalf("nil *APIError should not match any sentinel")
+	}
+	// Calling Error() on nil should not panic.
+	if got := err.Error(); got != "<nil>" {
+		t.Fatalf("nil *APIError Error() = %q, want \"<nil>\"", got)
+	}
+}
+
+// TestErrorsIs_EndToEnd_Unauthorized exercises the full networked path:
+// httptest server returns 401 with a Proton envelope, c.AuthInfo surfaces
+// the error, and errors.Is(err, ErrUnauthorized) reports true. This is the
+// contract callers actually use — type-level tests above are not enough.
+func TestErrorsIs_EndToEnd_Unauthorized(t *testing.T) {
+	_, c, cleanup := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"Code": 8002, "Error": "Invalid credentials"}`)
+	})
+	defer cleanup()
+
+	_, err := c.AuthInfo(context.Background(), "nobody@example.com")
+	if err == nil {
+		t.Fatal("expected error from 401 Proton envelope, got nil")
+	}
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("errors.Is(err, ErrUnauthorized) = false; want true (err=%v, type=%T)", err, err)
+	}
+}
+
+// TestErrorsIs_EndToEnd_InvalidCreds_AsCode covers the case where the server
+// replies with HTTP 200 but a Proton "invalid credentials" envelope code.
+// (Some Proton endpoints historically returned 2xx with an error code.)
+func TestErrorsIs_EndToEnd_InvalidCreds_AsCode(t *testing.T) {
+	_, c, cleanup := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"Code": 8002, "Error": "Invalid credentials"}`)
+	})
+	defer cleanup()
+
+	_, err := c.AuthInfo(context.Background(), "nobody@example.com")
+	if err == nil {
+		t.Fatal("expected error from 8002 envelope, got nil")
+	}
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("errors.Is(err, ErrUnauthorized) = false; want true (err=%v, type=%T)", err, err)
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("errors.As to *APIError failed")
+	}
+	if apiErr.Code != 8002 {
+		t.Fatalf("APIError.Code = %d, want 8002", apiErr.Code)
+	}
+}

--- a/import.go
+++ b/import.go
@@ -56,7 +56,7 @@ func (imp *Importer) ImportMessage(ctx context.Context, key string) (io.Writer, 
 
 func (imp *Importer) close() error {
 	if imp.closed {
-		return fmt.Errorf("protonmail: importer already closed")
+		return ErrImporterClosed
 	}
 	imp.closed = true
 
@@ -137,11 +137,11 @@ func (c *Client) Import(ctx context.Context, metadata map[string]*Message) (*Imp
 	hdr.Set("Content-Type", "application/json")
 	metadataWriter, err := mw.CreatePart(hdr)
 	if err != nil {
-		pw.CloseWithError(fmt.Errorf("protonmail: failed to write metadata"))
+		pw.CloseWithError(fmt.Errorf("protonmail: failed to write metadata: %w", err))
 		return nil, err
 	}
 	if err := json.NewEncoder(metadataWriter).Encode(metadata); err != nil {
-		pw.CloseWithError(fmt.Errorf("protonmail: failed to write metadata"))
+		pw.CloseWithError(fmt.Errorf("protonmail: failed to write metadata: %w", err))
 		return nil, err
 	}
 

--- a/keys.go
+++ b/keys.go
@@ -34,7 +34,7 @@ type PrivateKey struct {
 func (priv *PrivateKey) Entity() (*openpgp.Entity, error) {
 	keyRing, err := openpgp.ReadArmoredKeyRing(strings.NewReader(priv.PrivateKey))
 	if err != nil {
-		return nil, fmt.Errorf("failed to read private key: %v", err)
+		return nil, fmt.Errorf("failed to read private key: %w", err)
 	}
 	if len(keyRing) == 0 {
 		return nil, errors.New("private key is empty")
@@ -63,7 +63,7 @@ type PublicKey struct {
 func (pub *PublicKey) Entity() (*openpgp.Entity, error) {
 	keyRing, err := openpgp.ReadArmoredKeyRing(strings.NewReader(pub.PublicKey))
 	if err != nil {
-		return nil, fmt.Errorf("failed to read public key: %v", err)
+		return nil, fmt.Errorf("failed to read public key: %w", err)
 	}
 	if len(keyRing) == 0 {
 		return nil, errors.New("public key is empty")

--- a/protonmail.go
+++ b/protonmail.go
@@ -54,9 +54,20 @@ type RawAPIError struct {
 type APIError struct {
 	Code    int
 	Message string
+
+	// HTTPError, if non-nil, carries the underlying HTTP-level failure
+	// (status code, raw body) that produced this APIError. It is exposed
+	// via Unwrap so errors.Is(err, ErrRateLimited) and friends can match
+	// on HTTP status when Proton's application code is unknown.
+	HTTPError *HTTPError
 }
 
+// Error implements error. It is nil-safe: calling Error() on a nil receiver
+// returns "<nil>" instead of panicking.
 func (err *APIError) Error() string {
+	if err == nil {
+		return "<nil>"
+	}
 	return fmt.Sprintf("[%v] %v", err.Code, err.Message)
 }
 
@@ -234,21 +245,30 @@ func (c *Client) doJSON(ctx context.Context, req *http.Request, respData interfa
 		// we return).
 		_, _ = io.Copy(io.Discard, io.LimitReader(httpResp.Body, 1<<20))
 
+		httpErr := &HTTPError{
+			StatusCode: httpResp.StatusCode,
+			Status:     httpResp.Status,
+			Body:       bodyBytes,
+		}
+
 		// Best-effort: if the body parses as a Proton API error envelope,
 		// surface the existing *APIError shape so callers that already match
-		// on it keep working.
+		// on it keep working. Wire the HTTPError through so errors.Is can fall
+		// through to the HTTP status when the Proton "Code" is unknown.
 		var raw resp
 		if json.Unmarshal(bodyBytes, &raw) == nil && raw.RawAPIError != nil && raw.RawAPIError.Message != "" {
-			apiErr := &APIError{Code: raw.Code, Message: raw.RawAPIError.Message}
+			apiErr := &APIError{
+				Code:      raw.Code,
+				Message:   raw.RawAPIError.Message,
+				HTTPError: httpErr,
+			}
 			if c.debug {
 				log.Printf("<< %v %v: %v", req.Method, req.URL.Path, apiErr)
 			}
 			return apiErr
 		}
 
-		// TODO #3: replace with a typed *HTTPError once issue #3 lands.
-		// %q so binary/non-UTF8 bytes are safely Go-quoted in logs.
-		return fmt.Errorf("HTTP %d %s: %q", httpResp.StatusCode, httpResp.Status, bytes.TrimSpace(bodyBytes))
+		return httpErr
 	}
 
 	if err := json.NewDecoder(httpResp.Body).Decode(respData); err != nil {

--- a/srp.go
+++ b/srp.go
@@ -39,17 +39,17 @@ func decodeModulus(msg string) ([]byte, error) {
 
 	modulusKeyring, err := openpgp.ReadArmoredKeyRing(bytes.NewReader([]byte(modulusPubkey)))
 	if err != nil {
-		return nil, fmt.Errorf("cannot read modulus pubkey: %v", err)
+		return nil, fmt.Errorf("cannot read modulus pubkey: %w", err)
 	}
 
 	_, err = openpgp.CheckDetachedSignature(modulusKeyring, bytes.NewReader(block.Bytes), block.ArmoredSignature.Body, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check modulus signature: %v", err)
+		return nil, fmt.Errorf("failed to check modulus signature: %w", err)
 	}
 
 	b, err := base64.StdEncoding.DecodeString(string(block.Plaintext))
 	if err != nil {
-		return nil, fmt.Errorf("malformed SRP modulus: %v", err)
+		return nil, fmt.Errorf("malformed SRP modulus: %w", err)
 	}
 
 	return b, nil
@@ -162,7 +162,7 @@ func generateProofs(l int, hash func([]byte) []byte, modulusBytes, hashedBytes, 
 func (p *proofs) VerifyServerProof(serverProofString string) error {
 	serverProof, err := base64.StdEncoding.DecodeString(serverProofString)
 	if err != nil {
-		return fmt.Errorf("malformed SRP server proof: %v", err)
+		return fmt.Errorf("malformed SRP server proof: %w", err)
 	}
 
 	if subtle.ConstantTimeCompare(p.expectedServerProof, serverProof) != 1 {
@@ -180,12 +180,12 @@ func srp(password []byte, info *AuthInfo) (*proofs, error) {
 
 	serverEphemeral, err := base64.StdEncoding.DecodeString(info.serverEphemeral)
 	if err != nil {
-		return nil, fmt.Errorf("malformed SRP server ephemeral: %v", err)
+		return nil, fmt.Errorf("malformed SRP server ephemeral: %w", err)
 	}
 
 	salt, err := base64.StdEncoding.DecodeString(info.salt)
 	if err != nil {
-		return nil, fmt.Errorf("malformed SRP salt: %v", err)
+		return nil, fmt.Errorf("malformed SRP salt: %w", err)
 	}
 
 	hashed, err := hashPassword(info.version, password, salt, modulus)


### PR DESCRIPTION
Closes #3

**BREAKING:** `APIError` now implements `Is(target error) bool`; new typed `*HTTPError` returned for non-2xx HTTP failures; new sentinel errors exported.

### What changed
- New `errors.go`: `*HTTPError` type, sentinels (`ErrUnauthorized`, `ErrNotFound`, `ErrRateLimited`, `ErrNoUnlockableKeys`, `ErrImporterClosed`), `Is` methods on `*APIError`/`*HTTPError`.
- New `errors_test.go`: `errors.Is`/`errors.As` unwrap-chain coverage for every sentinel.
- 10 `fmt.Errorf %v` → `%w` wraps in `auth.go`, `keys.go`, `srp.go`.
- `attachments.go` GetAttachment non-2xx error swapped from stringly-formatted to `*HTTPError`.
- Sentinel replacements: `auth.go` `ErrNoUnlockableKeys`, `import.go` `ErrImporterClosed`.

### Acceptance
- [x] Every error-wrapping `fmt.Errorf` uses `%w` (10 sites)
- [x] `errors.Is(err, ErrUnauthorized)` works against API 401s (verified by tests)
- [x] `errors.As(err, &apiErr)` exposes Code/Message
- [x] Tests cover unwrap chains for every new sentinel

### Sister PR coordination
- #4 (HTTP body lifecycle) is in flight. Once merged, this branch will rebase to swap the `// TODO #3:` placeholders in `do`/`doJSON` to return `*HTTPError`.
- #5 (NewClient/options) is in flight. Once merged, this branch will rebase for field-rename adjustments (none expected to be substantive).

### Pair-programming flow
- Implementer: Driver agent
- Reviewer: Navigator agent (verdict: APPROVE)

Note: 2501 (ErrNotFound) and 401 (ErrUnauthorized) Proton code mappings are reasonable but not authoritatively verified against Proton API docs — follow-up validation suggested.