### PR TITLE
Fix HTTP response body lifecycle and non-2xx handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,16 @@ Note: pre-1.0 releases may break the API at any minor bump.
   with #6 (#5).
 - Default User-Agent now identifies the library
   (`protonmail-go/<version>`) instead of impersonating Firefox (#5, #D5).
+- Improved: `do` now consistently closes the response body on all error
+  paths and returns `(nil, err)` on transport errors (#4).
+
+### Fixed
+- `doJSON` now checks HTTP status before JSON-decoding (was producing
+  confusing decode errors on non-JSON 4xx/5xx responses). API-error-shaped
+  bodies still surface as `*APIError`; everything else returns a
+  status-bearing error (#4).
+- `GetAttachment` no longer leaks the response body on non-2xx responses;
+  the body is drained and closed before the error is returned (#4).
 
 ## [0.1.0] - TBD
 

--- a/attachments.go
+++ b/attachments.go
@@ -120,7 +120,11 @@ func (c *Client) GetAttachment(ctx context.Context, id string) (io.ReadCloser, e
 	}
 
 	if resp.StatusCode/100 != 2 {
-		return nil, fmt.Errorf("cannot get attachment %q: %v %v", id, resp.Status, resp.StatusCode)
+		// Drain (capped) and close the body before returning the error so the
+		// underlying TCP connection can be reused and we don't leak.
+		drainAndClose(resp.Body)
+		// TODO #3: replace with a typed *HTTPError once issue #3 lands.
+		return nil, fmt.Errorf("cannot get attachment %q: HTTP %d %s", id, resp.StatusCode, resp.Status)
 	}
 
 	return resp.Body, nil

--- a/body_lifecycle_test.go
+++ b/body_lifecycle_test.go
@@ -1,0 +1,340 @@
+package protonmail
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// trackingBody wraps an io.ReadCloser and records whether Close was called.
+type trackingBody struct {
+	io.ReadCloser
+	closed *atomic.Int32
+}
+
+func (b *trackingBody) Close() error {
+	b.closed.Add(1)
+	return b.ReadCloser.Close()
+}
+
+// trackingTransport wraps an http.RoundTripper and replaces every response
+// body with a trackingBody so tests can assert that callers (or the client)
+// closed the body.
+type trackingTransport struct {
+	inner    http.RoundTripper
+	closed   atomic.Int32
+	bodies   atomic.Int32 // total responses returned with a non-nil body
+}
+
+func (t *trackingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.inner.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	if resp.Body != nil {
+		t.bodies.Add(1)
+		resp.Body = &trackingBody{ReadCloser: resp.Body, closed: &t.closed}
+	}
+	return resp, nil
+}
+
+// TestDoReturnsBodyForCallerOn200 verifies do() returns a readable body on
+// 200 and that the caller is the one who closes it.
+func TestDoReturnsBodyForCallerOn200(t *testing.T) {
+	srv, c, cleanup := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello world"))
+	})
+	defer cleanup()
+	_ = srv
+
+	req, err := c.newRequest(context.Background(), http.MethodGet, "/anything", nil)
+	if err != nil {
+		t.Fatalf("newRequest: %v", err)
+	}
+	resp, err := c.do(context.Background(), req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(body) != "hello world" {
+		t.Errorf("body = %q, want %q", body, "hello world")
+	}
+}
+
+// TestDoTransportErrorReturnsNilResponse verifies that do() returns
+// (nil, err) on transport errors so callers don't accidentally try to
+// dereference a non-nil response.
+func TestDoTransportErrorReturnsNilResponse(t *testing.T) {
+	c, err := NewClient(
+		// Bogus URL; net/http will fail to connect. Loopback exemption permits http.
+		WithBaseURL("http://127.0.0.1:1"),
+		WithAppVersion("test/0.0.1"),
+		WithHTTPClient(&http.Client{Transport: &http.Transport{}}),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	req, err := c.newRequest(context.Background(), http.MethodGet, "/anything", nil)
+	if err != nil {
+		t.Fatalf("newRequest: %v", err)
+	}
+	resp, err := c.do(context.Background(), req)
+	if err == nil {
+		t.Fatalf("expected transport error, got nil")
+	}
+	if resp != nil {
+		t.Errorf("expected nil response on transport error, got %#v", resp)
+	}
+}
+
+// TestDoJSONNonJSON401Body verifies that doJSON, given a 401 with a
+// non-JSON body (e.g. an HTML error page), returns a useful non-nil error
+// instead of a JSON decode error, and does not panic.
+func TestDoJSONNonJSON401Body(t *testing.T) {
+	const html = "<html><body>nope</body></html>"
+	srv, c, cleanup := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(html))
+	})
+	defer cleanup()
+	_ = srv
+
+	req, err := c.newRequest(context.Background(), http.MethodGet, "/anything", nil)
+	if err != nil {
+		t.Fatalf("newRequest: %v", err)
+	}
+	var out struct{ X int }
+	err = c.doJSON(context.Background(), req, &out)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error %q does not mention 401", err.Error())
+	}
+	// Ensure it's not a JSON syntax error from trying to decode HTML.
+	if strings.Contains(err.Error(), "invalid character '<'") {
+		t.Errorf("error looks like a raw JSON decode failure: %v", err)
+	}
+}
+
+// TestDoJSONEmpty500 verifies that doJSON on a 500 with an empty body
+// surfaces a useful error instead of "EOF".
+func TestDoJSONEmpty500(t *testing.T) {
+	srv, c, cleanup := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer cleanup()
+	_ = srv
+
+	req, err := c.newRequest(context.Background(), http.MethodGet, "/anything", nil)
+	if err != nil {
+		t.Fatalf("newRequest: %v", err)
+	}
+	var out struct{ X int }
+	err = c.doJSON(context.Background(), req, &out)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error %q does not mention 500", err.Error())
+	}
+	if errors.Is(err, io.EOF) {
+		t.Errorf("error is bare io.EOF, expected a status-bearing error")
+	}
+}
+
+// TestDoJSONAPIErrorEnvelopeStillTyped verifies that when a non-2xx body
+// happens to parse as a Proton API error envelope, doJSON still returns
+// the existing *APIError shape so existing callers keep working.
+func TestDoJSONAPIErrorEnvelopeStillTyped(t *testing.T) {
+	srv, c, cleanup := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"Code":1234,"Error":"bad thing"}`))
+	})
+	defer cleanup()
+	_ = srv
+
+	req, err := c.newRequest(context.Background(), http.MethodGet, "/anything", nil)
+	if err != nil {
+		t.Fatalf("newRequest: %v", err)
+	}
+	var out struct{ X int }
+	err = c.doJSON(context.Background(), req, &out)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.Code != 1234 || apiErr.Message != "bad thing" {
+		t.Errorf("APIError = %+v, want Code=1234 Message=\"bad thing\"", apiErr)
+	}
+}
+
+// TestGetAttachmentNon2xxClosesBody verifies that GetAttachment, when the
+// API returns a non-2xx, has closed the response body before returning. We
+// detect this with a trackingTransport that wraps every response body.
+func TestGetAttachmentNon2xxClosesBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("<html>not found</html>"))
+	}))
+	defer srv.Close()
+
+	tt := &trackingTransport{inner: http.DefaultTransport}
+	c, err := NewClient(
+		WithBaseURL(srv.URL),
+		WithAppVersion("test/0.0.1"),
+		WithHTTPClient(&http.Client{Transport: tt}),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	rc, err := c.GetAttachment(context.Background(), "att-id")
+	if err == nil {
+		t.Fatalf("expected error, got nil and rc=%v", rc)
+	}
+	if rc != nil {
+		t.Errorf("expected nil ReadCloser on error, got %v", rc)
+		_ = rc.Close()
+	}
+	if got, want := tt.bodies.Load(), int32(1); got != want {
+		t.Fatalf("expected %d wrapped body, got %d", want, got)
+	}
+	// Exactly one close: catches both leaks (0) and double-close regressions (>1).
+	if got := tt.closed.Load(); got != 1 {
+		t.Errorf("response body close count = %d, want 1, on non-2xx GetAttachment path", got)
+	}
+}
+
+// TestGetAttachment2xxBodyIsCallersResponsibility verifies the success path
+// hands the (still-open) body back to the caller.
+func TestGetAttachment2xxBodyIsCallersResponsibility(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ciphertext-bytes"))
+	}))
+	defer srv.Close()
+
+	tt := &trackingTransport{inner: http.DefaultTransport}
+	c, err := NewClient(
+		WithBaseURL(srv.URL),
+		WithAppVersion("test/0.0.1"),
+		WithHTTPClient(&http.Client{Transport: tt}),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	rc, err := c.GetAttachment(context.Background(), "att-id")
+	if err != nil {
+		t.Fatalf("GetAttachment: %v", err)
+	}
+	// Body should NOT yet be closed — caller owns it.
+	if got := tt.closed.Load(); got != 0 {
+		t.Errorf("body closed prematurely on 2xx (closed=%d)", got)
+	}
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != "ciphertext-bytes" {
+		t.Errorf("body = %q, want %q", got, "ciphertext-bytes")
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := tt.closed.Load(); got != 1 {
+		t.Errorf("body close count = %d, want 1", got)
+	}
+}
+
+// TestDoJSONClosesBodyOnAllPaths uses trackingTransport to verify that
+// doJSON closes the body on success, on non-2xx, and on JSON decode error.
+func TestDoJSONClosesBodyOnAllPaths(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		respObj interface{}
+		wantErr bool
+	}{
+		{
+			name: "200 valid JSON",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(200)
+				_, _ = w.Write([]byte(`{"X":1}`))
+			},
+			respObj: &struct{ X int }{},
+			wantErr: false,
+		},
+		{
+			name: "404 HTML body",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(404)
+				_, _ = w.Write([]byte("<html/>"))
+			},
+			respObj: &struct{ X int }{},
+			wantErr: true,
+		},
+		{
+			name: "200 malformed JSON",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(200)
+				_, _ = w.Write([]byte("not-json"))
+			},
+			respObj: &struct{ X int }{},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(tc.handler)
+			defer srv.Close()
+
+			tt := &trackingTransport{inner: http.DefaultTransport}
+			c, err := NewClient(
+				WithBaseURL(srv.URL),
+				WithAppVersion("test/0.0.1"),
+				WithHTTPClient(&http.Client{Transport: tt}),
+			)
+			if err != nil {
+				t.Fatalf("NewClient: %v", err)
+			}
+			req, err := c.newRequest(context.Background(), http.MethodGet, "/anything", nil)
+			if err != nil {
+				t.Fatalf("newRequest: %v", err)
+			}
+			err = c.doJSON(context.Background(), req, tc.respObj)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got, want := tt.bodies.Load(), int32(1); got != want {
+				t.Fatalf("expected %d wrapped body, got %d", want, got)
+			}
+			// Exactly one close: catches leaks (0) and double-close regressions (>1).
+			if got := tt.closed.Load(); got != 1 {
+				t.Errorf("body close count = %d, want 1", got)
+			}
+		})
+	}
+}

--- a/protonmail.go
+++ b/protonmail.go
@@ -151,6 +151,13 @@ func (c *Client) newJSONRequest(ctx context.Context, method, path string, body i
 	return req, nil
 }
 
+// do issues req and returns the response. On success (err == nil) the caller
+// owns resp.Body and is responsible for draining and closing it. On error,
+// do guarantees that any response body it obtained has been drained and
+// closed, and returns (nil, err).
+//
+// A 401 with a configured ReAuth callback triggers a single re-auth + retry;
+// the original 401 response body is drained and closed before the retry.
 func (c *Client) do(ctx context.Context, req *http.Request) (*http.Response, error) {
 	req.Header.Set("User-Agent", c.userAgent)
 
@@ -158,23 +165,30 @@ func (c *Client) do(ctx context.Context, req *http.Request) (*http.Response, err
 	// http.DefaultClient and WithHTTPClient(nil) errors at construction.
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return resp, err
+		// On transport error resp is nil per net/http contract; nothing to close.
+		return nil, err
 	}
 
-	// Check if access token has expired
+	// Check if access token has expired. Retry is only safe if the request
+	// body can be replayed: either there is no body, or GetBody was set so
+	// the body can be re-read. If a 401 arrives with a non-replayable body
+	// (req.Body != nil && GetBody == nil) we silently skip the retry and
+	// surface the 401 to the caller — re-sending an already-consumed body
+	// would send an empty body and corrupt the request. TODO #6: log this
+	// case via the structured logger once it exists.
 	_, hasAuth := req.Header["Authorization"]
 	canRetry := req.Body == nil || req.GetBody != nil
 	if resp.StatusCode == http.StatusUnauthorized && hasAuth && c.reauth != nil && canRetry {
-		resp.Body.Close()
+		drainAndClose(resp.Body)
 		c.accessToken = ""
 		if err := c.reauth(ctx); err != nil {
-			return resp, err
+			return nil, err
 		}
 		c.setRequestAuthorization(req) // Access token has changed
 		if req.Body != nil {
 			body, err := req.GetBody()
 			if err != nil {
-				return resp, err
+				return nil, err
 			}
 			req.Body = body
 		}
@@ -184,6 +198,17 @@ func (c *Client) do(ctx context.Context, req *http.Request) (*http.Response, err
 	return resp, nil
 }
 
+// drainAndClose drains rc up to a small cap so the connection can be reused,
+// then closes it. Safe to call with a nil ReadCloser.
+func drainAndClose(rc io.ReadCloser) {
+	if rc == nil {
+		return
+	}
+	// Cap drain to avoid unbounded reads on a hostile server.
+	_, _ = io.Copy(io.Discard, io.LimitReader(rc, 64<<10))
+	_ = rc.Close()
+}
+
 func (c *Client) doJSON(ctx context.Context, req *http.Request, respData interface{}) error {
 	req.Header.Set("Accept", "application/json")
 
@@ -191,13 +216,42 @@ func (c *Client) doJSON(ctx context.Context, req *http.Request, respData interfa
 		respData = new(resp)
 	}
 
-	resp, err := c.do(ctx, req)
+	httpResp, err := c.do(ctx, req)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer httpResp.Body.Close()
 
-	if err := json.NewDecoder(resp.Body).Decode(respData); err != nil {
+	// Status check FIRST. A non-2xx with a non-JSON body (e.g. an HTML error
+	// page from an upstream proxy) used to surface as a confusing JSON decode
+	// error; now it always becomes a typed error containing the status.
+	if httpResp.StatusCode/100 != 2 {
+		// Read up to 64KB of the error body for diagnostic context.
+		bodyBytes, _ := io.ReadAll(io.LimitReader(httpResp.Body, 64<<10))
+		// Drain anything left so the connection can be reused. Cap the
+		// drain to 1 MB so a hostile/slow-loris server can't pin this
+		// goroutine forever (the deferred Close above never fires until
+		// we return).
+		_, _ = io.Copy(io.Discard, io.LimitReader(httpResp.Body, 1<<20))
+
+		// Best-effort: if the body parses as a Proton API error envelope,
+		// surface the existing *APIError shape so callers that already match
+		// on it keep working.
+		var raw resp
+		if json.Unmarshal(bodyBytes, &raw) == nil && raw.RawAPIError != nil && raw.RawAPIError.Message != "" {
+			apiErr := &APIError{Code: raw.Code, Message: raw.RawAPIError.Message}
+			if c.debug {
+				log.Printf("<< %v %v: %v", req.Method, req.URL.Path, apiErr)
+			}
+			return apiErr
+		}
+
+		// TODO #3: replace with a typed *HTTPError once issue #3 lands.
+		// %q so binary/non-UTF8 bytes are safely Go-quoted in logs.
+		return fmt.Errorf("HTTP %d %s: %q", httpResp.StatusCode, httpResp.Status, bytes.TrimSpace(bodyBytes))
+	}
+
+	if err := json.NewDecoder(httpResp.Body).Decode(respData); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Closes #4

Fixes connection-leak risks and confusing error messages on non-2xx responses.

### What changed
- `do`: response body is consistently closed on all error paths. 401 retry path drains+closes the original 401 body via `drainAndClose` (capped at 64KB) before invoking ReAuth and recursing.
- `doJSON`: status-checks BEFORE JSON decode. On non-2xx: reads up to 64KB for diagnostic context, drains rest, returns either `*APIError` (if body parses as Proton envelope) or a placeholder `fmt.Errorf` (will be `*HTTPError` after #3 merges).
- `GetAttachment`: drains+closes body on non-2xx (was leaking the connection).
- New `body_lifecycle_test.go` (8 tests) including connection-close detection via custom `RoundTripper`.

### Acceptance
- [x] `staticcheck SA5001` clean
- [x] No body leaks on error paths (verified via `trackingTransport` test)
- [x] Non-2xx responses return useful errors regardless of body content (HTML, empty, JSON-malformed all covered)
- [x] Test for 4xx with non-JSON body present (`TestDoJSONNonJSON401Body`)

### Sister PR coordination
- #3 (typed errors) is in flight. Two `// TODO #3:` placeholders in this PR mark sites where `fmt.Errorf("HTTP %d %s: %s", ...)` will be swapped to `*HTTPError` once #3 merges.
- #5 (NewClient) is in flight. Will need rebase after #5 merges to use renamed unexported fields (`c.HTTPClient` → `c.httpClient`, etc.) — purely mechanical.

### Pair-programming flow
- Implementer: Driver agent
- Reviewer: Navigator agent (verdict: APPROVE)