### PR TITLE
Add package doc.go and godoc comments on every exported symbol

### DIFF
--- a/addresses.go
+++ b/addresses.go
@@ -5,44 +5,67 @@ import (
 	"net/http"
 )
 
-type (
-	AddressSend   int
-	AddressStatus int
-	AddressType   int
-)
+// AddressSend describes whether an Address can be used to send mail and at
+// what priority (primary vs secondary).
+type AddressSend int
+
+// AddressStatus reports whether an Address is enabled or disabled on the
+// account.
+type AddressStatus int
+
+// AddressType classifies an Address as the account's original, an alias,
+// or a custom-domain address.
+type AddressType int
 
 const (
+	// AddressSendDisabled indicates the address cannot be used to send.
 	AddressSendDisabled AddressSend = iota
+	// AddressSendPrimary indicates the primary sending address.
 	AddressSendPrimary
+	// AddressSendSecondary indicates a non-primary sending address.
 	AddressSendSecondary
 )
 
 const (
+	// AddressDisabled indicates the address is disabled.
 	AddressDisabled AddressStatus = iota
+	// AddressEnabled indicates the address is enabled.
 	AddressEnabled
 )
 
 const (
+	// AddressOriginal is the account's original signup address.
 	AddressOriginal AddressType = iota
+	// AddressAlias is a Proton-provided alias of the original.
 	AddressAlias
+	// AddressCustom is an address on a custom domain.
 	AddressCustom
 )
 
+// Address is a single email address attached to the Proton account. Keys
+// holds the private keys associated with the address (encrypted; see Unlock).
 type Address struct {
 	ID          string
 	DomainID    string
 	Email       string
 	Send        AddressSend
+	// Receive is non-zero if the address is allowed to receive mail.
 	Receive     int
 	Status      AddressStatus
 	Type        AddressType
 	Order       int64
 	DisplayName string
-	Signature   string // HTML
-	HasKeys     int
-	Keys        []*PrivateKey
+	// Signature is an HTML signature appended to outgoing mail from this
+	// address.
+	Signature string
+	// HasKeys is non-zero if the address has at least one key.
+	HasKeys int
+	Keys    []*PrivateKey
 }
 
+// ListAddresses returns every address attached to the current account. The
+// returned addresses' Keys field carries the (still-encrypted) private keys;
+// they are decrypted as a side effect of Unlock.
 func (c *Client) ListAddresses(ctx context.Context) ([]*Address, error) {
 	// TODO: Page, PageSize
 	req, err := c.newRequest(ctx, http.MethodGet, "/addresses", nil)

--- a/attachments.go
+++ b/attachments.go
@@ -15,20 +15,26 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
 )
 
+// AttachmentKey pairs an attachment ID with a base64-encoded session key
+// and the cipher algorithm name (e.g. "aes256").
 type AttachmentKey struct {
 	ID   string
 	Key  string
 	Algo string
 }
 
+// Attachment is the metadata for an attachment associated with a message.
+// The payload is fetched separately via GetAttachment and decrypted with
+// Read.
 type Attachment struct {
-	ID         string
-	MessageID  string
-	Name       string
-	Size       int
-	MIMEType   string
-	ContentID  string
-	KeyPackets string // encrypted with the user's key, base64-encoded
+	ID        string
+	MessageID string
+	Name      string
+	Size      int
+	MIMEType  string
+	ContentID string
+	// KeyPackets is the session key encrypted to the user's key, base64-encoded.
+	KeyPackets string
 	//Headers    map[string]string
 	Signature string
 
@@ -68,8 +74,9 @@ func (att *Attachment) GenerateKey(to []*openpgp.Entity) (*packet.EncryptedKey, 
 	return unencryptedKey, nil
 }
 
-// Encrypt encrypts to w the data that will be written to the returned
-// io.WriteCloser.
+// Encrypt encrypts plaintext written to the returned io.WriteCloser and
+// emits the ciphertext to the supplied ciphertext writer. Close the
+// returned WriteCloser to flush the encryption stream.
 //
 // Prior to calling Encrypt, an attachment key must have been generated with
 // GenerateKey.
@@ -91,6 +98,9 @@ func (att *Attachment) Encrypt(ciphertext io.Writer, signed *openpgp.Entity) (cl
 	return symetricallyEncrypt(ciphertext, att.unencryptedKey, nil, hints, config)
 }
 
+// Read decrypts the attachment payload streamed from ciphertext, using
+// att.KeyPackets and the supplied keyring. If att has no key packets the
+// data is returned verbatim. prompt is invoked when a private key is locked.
 func (att *Attachment) Read(ciphertext io.Reader, keyring openpgp.KeyRing, prompt openpgp.PromptFunction) (*openpgp.MessageDetails, error) {
 	if len(att.KeyPackets) == 0 {
 		return &openpgp.MessageDetails{

--- a/auth.go
+++ b/auth.go
@@ -20,6 +20,9 @@ type authInfoReq struct {
 	Username string
 }
 
+// AuthInfo carries the SRP session parameters returned by AuthInfo. Its
+// fields are intentionally unexported: they are inputs to the SRP handshake
+// performed by Auth and are not useful to inspect directly.
 type AuthInfo struct {
 	version         int
 	modulus         string
@@ -28,6 +31,9 @@ type AuthInfo struct {
 	srpSession      string
 }
 
+// AuthInfoResp is the wire-level response returned by /auth/info. Most
+// callers should use AuthInfo via the Client.AuthInfo helper rather than
+// decoding this directly.
 type AuthInfoResp struct {
 	resp
 	AuthInfo
@@ -48,6 +54,10 @@ func (resp *AuthInfoResp) authInfo() *AuthInfo {
 	return info
 }
 
+// AuthInfo fetches the SRP parameters required to authenticate as username.
+// It is the first step of the authentication flow; callers normally pass the
+// returned *AuthInfo to Auth. ctx controls cancellation of the underlying
+// request.
 func (c *Client) AuthInfo(ctx context.Context, username string) (*AuthInfo, error) {
 	reqData := &authInfoReq{
 		Username: username,
@@ -73,14 +83,23 @@ type authReq struct {
 	ClientProof     string
 }
 
+// PasswordMode describes whether the account uses a single login password
+// (PasswordSingle) or separate login and mailbox passwords (PasswordTwo).
 type PasswordMode int
 
 const (
+	// PasswordSingle indicates the same password unlocks login and mailbox.
 	PasswordSingle PasswordMode = 1
-	PasswordTwo                 = 2
+	// PasswordTwo indicates the account uses a separate mailbox password.
+	PasswordTwo = 2
 )
 
+// Auth is the result of a successful authentication. It carries the session
+// identifiers (UID, AccessToken, RefreshToken) used for subsequent requests,
+// the absolute ExpiresAt at which AccessToken stops being valid, and metadata
+// about the account's password and 2FA configuration.
 type Auth struct {
+	// ExpiresAt is the absolute time at which AccessToken stops being valid.
 	ExpiresAt    time.Time
 	Scope        string
 	UID          string
@@ -88,8 +107,13 @@ type Auth struct {
 	RefreshToken string
 	UserID       string
 	EventID      string
+	// PasswordMode reports whether the account uses a single or two-password
+	// login.
 	PasswordMode PasswordMode
-	TwoFactor    struct {
+	// TwoFactor describes the 2FA methods enabled on the account. Enabled is
+	// non-zero if any 2FA method is enabled; TOTP is non-zero if TOTP is
+	// enabled.
+	TwoFactor struct {
 		Enabled int
 		U2F     interface{} // TODO
 		TOTP    int
@@ -110,6 +134,12 @@ func (resp *authResp) auth() *Auth {
 	return auth
 }
 
+// Auth completes the SRP handshake and exchanges credentials for a session.
+// If info is nil it is fetched via AuthInfo. On success the Client retains
+// the resulting UID and AccessToken so subsequent calls are authenticated.
+//
+// On invalid credentials the error wraps ErrUnauthorized; callers should
+// check with errors.Is(err, protonmail.ErrUnauthorized).
 func (c *Client) Auth(ctx context.Context, username, password string, info *AuthInfo) (*Auth, error) {
 	if info == nil {
 		var err error
@@ -150,6 +180,10 @@ func (c *Client) Auth(ctx context.Context, username, password string, info *Auth
 	return auth, nil
 }
 
+// AuthTOTP submits a six-digit TOTP code to satisfy the second factor of
+// authentication. It must be called after Auth on accounts that have TOTP
+// enabled (see Auth.TwoFactor.TOTP). The returned scope describes the
+// permissions of the now-elevated session.
 func (c *Client) AuthTOTP(ctx context.Context, code string) (scope string, err error) {
 	reqData := struct {
 		TwoFactorCode string
@@ -182,6 +216,10 @@ type authRefreshReq struct {
 	RedirectURI  string
 }
 
+// AuthRefresh exchanges expiredAuth.RefreshToken for a fresh session. It is
+// the conventional implementation of the WithReAuth callback: when a request
+// receives 401 the Client invokes the registered callback, which usually
+// calls AuthRefresh and stores the new tokens for the next attempt.
 func (c *Client) AuthRefresh(ctx context.Context, expiredAuth *Auth) (*Auth, error) {
 	reqData := &authRefreshReq{
 		RefreshToken: expiredAuth.RefreshToken,
@@ -207,6 +245,9 @@ func (c *Client) AuthRefresh(ctx context.Context, expiredAuth *Auth) (*Auth, err
 	return auth, nil
 }
 
+// ListKeySalts fetches the per-key salt material the client needs in order
+// to derive the password used to unlock each private key. The returned map
+// is keyed by key ID; values may be nil for keys that have no salt.
 func (c *Client) ListKeySalts(ctx context.Context) (map[string][]byte, error) {
 	req, err := c.newRequest(ctx, http.MethodGet, "/keys/salts", nil)
 	if err != nil {
@@ -333,6 +374,14 @@ func (c *Client) unlockKeyRing(keys []*PrivateKey, userKeyRing openpgp.EntityLis
 	return keyRing, nil
 }
 
+// Unlock decrypts the user and address private keys using passphrase and the
+// per-key salts returned by ListKeySalts, and stores the resulting key ring
+// on the Client so encrypted messages can be read and sent. auth is the
+// session returned by Auth (or by AuthTOTP-completed flow).
+//
+// If no key on the account can be unlocked the returned error wraps
+// ErrNoUnlockableKeys; callers can check with errors.Is. Address keys that
+// fail to unlock are logged at warn level and skipped.
 func (c *Client) Unlock(ctx context.Context, auth *Auth, keySalts map[string][]byte, passphrase string) (openpgp.EntityList, error) {
 	c.uid = auth.UID
 	c.accessToken = auth.AccessToken
@@ -376,6 +425,16 @@ func (c *Client) Unlock(ctx context.Context, auth *Auth, keySalts map[string][]b
 	return keyRing, nil
 }
 
+// Logout invalidates the current session on the Proton API and, on success,
+// clears the Client's cached UID, access token, and key ring.
+//
+// If the request itself fails (network error, etc.) the local auth state is
+// preserved so that callers can retry. Callers should not assume that
+// subsequent requests will fail with ErrUnauthorized: endpoints that do not
+// require authentication (for example AuthInfo) will still succeed, and
+// authenticated requests issued after a successful Logout will simply
+// receive a fresh 401 from the server. The Client does not gate calls on
+// the cleared local state.
 func (c *Client) Logout(ctx context.Context) error {
 	req, err := c.newRequest(ctx, http.MethodDelete, "/auth", nil)
 	if err != nil {

--- a/calendar.go
+++ b/calendar.go
@@ -9,19 +9,30 @@ import (
 
 const calendarPath = "/calendar/v1"
 
+// CalendarFlags is a bitmask of Proton Calendar flags. Concrete values are
+// not yet enumerated by this client.
 type CalendarFlags int
 
+// Calendar is a single Proton Calendar. Display is non-zero if the calendar
+// is currently shown in the user's UI.
 type Calendar struct {
 	ID          string
 	Name        string
 	Description string
 	Color       string
-	Display     int
-	Flags       CalendarFlags
+	// Display is non-zero if the calendar is shown in the UI.
+	Display int
+	Flags   CalendarFlags
 }
 
+// CalendarEventPermissions is a bitmask describing what the current user is
+// allowed to do with a CalendarEvent. Concrete values are not yet enumerated
+// by this client.
 type CalendarEventPermissions int
 
+// CalendarEvent is a single event within a Calendar. The vCard-like payloads
+// are carried in SharedEvents and PersonalEvent as encrypted/signed
+// CalendarEventCard values.
 type CalendarEvent struct {
 	ID                string
 	CalendarID        string
@@ -36,8 +47,13 @@ type CalendarEvent struct {
 	PersonalEvent     []CalendarEventCard
 }
 
+// CalendarEventCardType describes how a CalendarEventCard is protected.
+// Concrete values are not yet enumerated by this client.
 type CalendarEventCardType int
 
+// CalendarEventCard is one of the encrypted or signed payloads attached to
+// a CalendarEvent. MemberID identifies which calendar member the card was
+// written for (empty for shared cards).
 type CalendarEventCard struct {
 	Type      CalendarEventCardType
 	Data      string
@@ -45,6 +61,7 @@ type CalendarEventCard struct {
 	MemberID  string
 }
 
+// ListCalendars returns a paginated list of the user's Proton Calendars.
 func (c *Client) ListCalendars(ctx context.Context, page, pageSize int) ([]*Calendar, error) {
 	v := url.Values{}
 	v.Set("Page", strconv.Itoa(page))
@@ -68,12 +85,16 @@ func (c *Client) ListCalendars(ctx context.Context, page, pageSize int) ([]*Cale
 	return respData.Calendars, nil
 }
 
+// CalendarEventFilter narrows the result set returned by ListCalendarEvents.
+// Start and End are Unix timestamps in seconds; Timezone is an IANA TZ name.
 type CalendarEventFilter struct {
 	Start, End     int64
 	Timezone       string
 	Page, PageSize int
 }
 
+// ListCalendarEvents returns a page of events from the calendar identified
+// by calendarID, narrowed by filter.
 func (c *Client) ListCalendarEvents(ctx context.Context, calendarID string, filter *CalendarEventFilter) ([]*CalendarEvent, error) {
 	v := url.Values{}
 	v.Set("Start", strconv.FormatInt(filter.Start, 10))

--- a/contacts.go
+++ b/contacts.go
@@ -13,6 +13,9 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp/armor"
 )
 
+// Contact is a single entry in the user's address book. ContactEmails and
+// Cards are populated only by GetContact (and ListContactsExport for Cards),
+// not by the lighter ListContacts.
 type Contact struct {
 	ID         string
 	Name       string
@@ -27,8 +30,11 @@ type Contact struct {
 	Cards         []*ContactCard
 }
 
+// ContactEmailDefaults is a bitmask of "default for ..." flags carried on a
+// ContactEmail (e.g. default From, default sign).
 type ContactEmailDefaults int
 
+// ContactEmail is a single email address attached to a Contact.
 type ContactEmail struct {
 	ID        string
 	Email     string
@@ -42,15 +48,24 @@ type ContactEmail struct {
 	Name string
 }
 
+// ContactCardType describes how a vCard payload is protected on a Contact:
+// cleartext, encrypted, signed, or both encrypted and signed.
 type ContactCardType int
 
 const (
+	// ContactCardCleartext is an unprotected vCard payload.
 	ContactCardCleartext ContactCardType = iota
+	// ContactCardEncrypted is a vCard encrypted to the user.
 	ContactCardEncrypted
+	// ContactCardSigned is a cleartext vCard with a detached signature.
 	ContactCardSigned
+	// ContactCardEncryptedAndSigned is an encrypted vCard with a detached
+	// signature over the original plaintext.
 	ContactCardEncryptedAndSigned
 )
 
+// Signed reports whether t indicates a signed card (signed or
+// encrypted-and-signed).
 func (t ContactCardType) Signed() bool {
 	switch t {
 	case ContactCardSigned, ContactCardEncryptedAndSigned:
@@ -60,6 +75,8 @@ func (t ContactCardType) Signed() bool {
 	}
 }
 
+// Encrypted reports whether t indicates an encrypted card (encrypted or
+// encrypted-and-signed).
 func (t ContactCardType) Encrypted() bool {
 	switch t {
 	case ContactCardEncrypted, ContactCardEncryptedAndSigned:
@@ -69,12 +86,19 @@ func (t ContactCardType) Encrypted() bool {
 	}
 }
 
+// ContactCard is a vCard payload (Data) carried on a Contact, optionally
+// encrypted and/or detached-signed (Signature). Its interpretation is
+// governed by Type; use Read to transparently decrypt and verify against a
+// key ring.
 type ContactCard struct {
 	Type      ContactCardType
 	Data      string
 	Signature string
 }
 
+// NewEncryptedContactCard returns a ContactCard whose Data is the vCard read
+// from r, encrypted to the recipients in to. If signer is non-nil the card
+// is also detached-signed and the type is set to ContactCardEncryptedAndSigned.
 func NewEncryptedContactCard(r io.Reader, to []*openpgp.Entity, signer *openpgp.Entity) (*ContactCard, error) {
 	// TODO: sign and encrypt at the same time
 
@@ -122,6 +146,8 @@ func NewEncryptedContactCard(r io.Reader, to []*openpgp.Entity, signer *openpgp.
 	return card, nil
 }
 
+// NewSignedContactCard returns a ContactCard whose Data is the cleartext
+// vCard read from r and Signature is a detached signature over it.
 func NewSignedContactCard(r io.Reader, signer *openpgp.Entity) (*ContactCard, error) {
 	var msg, sig bytes.Buffer
 	r = io.TeeReader(r, &msg)
@@ -163,6 +189,10 @@ func (r *detachedSignatureReader) Read(p []byte) (n int, err error) {
 	return
 }
 
+// Read decrypts and verifies card against keyring and returns OpenPGP
+// message details whose UnverifiedBody yields the card's plaintext vCard
+// payload. For unencrypted cards the body is yielded verbatim; signature
+// verification still runs when the card is signed.
 func (card *ContactCard) Read(keyring openpgp.KeyRing) (*openpgp.MessageDetails, error) {
 	if !card.Type.Encrypted() {
 		md := &openpgp.MessageDetails{
@@ -211,15 +241,22 @@ func (card *ContactCard) Read(keyring openpgp.KeyRing) (*openpgp.MessageDetails,
 	return md, nil
 }
 
+// ContactExport is a Contact represented purely by its raw cards, as
+// returned by ListContactsExport. It is the canonical bulk-export shape.
 type ContactExport struct {
 	ID    string
 	Cards []*ContactCard
 }
 
+// ContactImport is the per-contact payload submitted to CreateContacts.
+// Cards are encrypted and/or signed using the helpers in this package.
 type ContactImport struct {
 	Cards []*ContactCard
 }
 
+// ListContacts returns a paginated list of contacts. ContactEmails and
+// Cards are NOT populated on the returned contacts — use GetContact for the
+// full record, or ListContactsExport for the bulk-export shape.
 func (c *Client) ListContacts(ctx context.Context, page, pageSize int) (total int, contacts []*Contact, err error) {
 	v := url.Values{}
 	v.Set("Page", strconv.Itoa(page))
@@ -244,6 +281,9 @@ func (c *Client) ListContacts(ctx context.Context, page, pageSize int) (total in
 	return respData.Total, respData.Contacts, nil
 }
 
+// ListContactsEmails returns a paginated list of all email addresses across
+// the user's contacts. Each ContactEmail.ContactID identifies the parent
+// Contact.
 func (c *Client) ListContactsEmails(ctx context.Context, page, pageSize int) (total int, emails []*ContactEmail, err error) {
 	v := url.Values{}
 	v.Set("Page", strconv.Itoa(page))
@@ -268,6 +308,8 @@ func (c *Client) ListContactsEmails(ctx context.Context, page, pageSize int) (to
 	return respData.Total, respData.ContactEmails, nil
 }
 
+// ListContactsExport returns a paginated list of contacts in their raw
+// card-only export shape, suitable for backup or migration.
 func (c *Client) ListContactsExport(ctx context.Context, page, pageSize int) (total int, contacts []*ContactExport, err error) {
 	v := url.Values{}
 	v.Set("Page", strconv.Itoa(page))
@@ -292,6 +334,8 @@ func (c *Client) ListContactsExport(ctx context.Context, page, pageSize int) (to
 	return respData.Total, respData.Contacts, nil
 }
 
+// GetContact fetches a single contact by ID, including its ContactEmails
+// and Cards. Returns a wrapped ErrNotFound if no such contact exists.
 func (c *Client) GetContact(ctx context.Context, id string) (*Contact, error) {
 	req, err := c.newRequest(ctx, http.MethodGet, "/contacts/"+id, nil)
 	if err != nil {
@@ -309,6 +353,9 @@ func (c *Client) GetContact(ctx context.Context, id string) (*Contact, error) {
 	return respData.Contact, nil
 }
 
+// CreateContactResp is the per-contact result returned by CreateContacts.
+// Index is the position in the request slice; Response carries the created
+// Contact or a per-item error.
 type CreateContactResp struct {
 	Index    int
 	Response struct {
@@ -317,10 +364,15 @@ type CreateContactResp struct {
 	}
 }
 
+// Err returns the per-contact API error from the response, or nil if the
+// individual create succeeded.
 func (resp *CreateContactResp) Err() error {
 	return resp.Response.Err()
 }
 
+// CreateContacts creates a batch of contacts. Each request element gets a
+// matching CreateContactResp; per-item failures are surfaced via Err on the
+// individual response, not as a top-level error.
 func (c *Client) CreateContacts(ctx context.Context, contacts []*ContactImport) ([]*CreateContactResp, error) {
 	reqData := struct {
 		Contacts                  []*ContactImport
@@ -342,6 +394,8 @@ func (c *Client) CreateContacts(ctx context.Context, contacts []*ContactImport) 
 	return respData.Responses, nil
 }
 
+// UpdateContact replaces the cards on the contact identified by id with
+// those in contact. Returns the updated Contact.
 func (c *Client) UpdateContact(ctx context.Context, id string, contact *ContactImport) (*Contact, error) {
 	req, err := c.newJSONRequest(ctx, http.MethodPut, "/contacts/"+id, contact)
 	if err != nil {
@@ -359,6 +413,8 @@ func (c *Client) UpdateContact(ctx context.Context, id string, contact *ContactI
 	return respData.Contact, nil
 }
 
+// DeleteContactResp is the per-contact result returned by DeleteContacts.
+// Use Err to test whether the individual delete succeeded.
 type DeleteContactResp struct {
 	ID       string
 	Response struct {
@@ -366,10 +422,14 @@ type DeleteContactResp struct {
 	}
 }
 
+// Err returns the per-contact API error from the response, or nil if the
+// individual delete succeeded.
 func (resp *DeleteContactResp) Err() error {
 	return resp.Response.Err()
 }
 
+// DeleteContacts deletes a batch of contacts by ID. Per-item failures are
+// surfaced via Err on the individual response, not as a top-level error.
 func (c *Client) DeleteContacts(ctx context.Context, ids []string) ([]*DeleteContactResp, error) {
 	reqData := struct {
 		IDs []string
@@ -390,6 +450,8 @@ func (c *Client) DeleteContacts(ctx context.Context, ids []string) ([]*DeleteCon
 	return respData.Responses, nil
 }
 
+// DeleteAllContacts deletes every contact in the user's address book. There
+// is no undo.
 func (c *Client) DeleteAllContacts(ctx context.Context) error {
 	req, err := c.newRequest(ctx, http.MethodDelete, "/contacts", nil)
 	if err != nil {

--- a/conversations.go
+++ b/conversations.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 )
 
+// Conversation is a thread of messages on the same subject/participants.
+// NumMessages, NumUnread and NumAttachments aggregate across the thread.
 type Conversation struct {
 	ID             string
 	Order          int64
@@ -21,6 +23,10 @@ type Conversation struct {
 	LabelIDs       []string
 }
 
+// GetConversation fetches a conversation and the messages within it. If
+// msgID is non-empty the server may use it to scope what is returned (the
+// Proton API treats it as a hint to expand around a particular message).
+// Returns a wrapped ErrNotFound when no such conversation exists.
 func (c *Client) GetConversation(ctx context.Context, id, msgID string) (*Conversation, []*Message, error) {
 	v := url.Values{}
 	if msgID != "" {

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,70 @@
+// Package protonmail is a Go client for the (unofficial) Proton Mail API.
+//
+// # Status
+//
+// This is a v0.x library. The API will churn until v1.0.0; pin to a
+// specific tag in production. The Proton Mail API itself is unofficial,
+// reverse-engineered, and unstable; see the project README for the
+// stability disclaimer.
+//
+// # Quickstart
+//
+//	package main
+//
+//	import (
+//	    "context"
+//	    "log"
+//
+//	    "github.com/joestump/protonmail-go"
+//	)
+//
+//	func main() {
+//	    c, err := protonmail.NewClient(
+//	        protonmail.WithAppVersion("Other"),
+//	    )
+//	    if err != nil {
+//	        log.Fatal(err)
+//	    }
+//
+//	    if _, err := c.AuthInfo(context.Background(), "user@example.com"); err != nil {
+//	        log.Fatal(err)
+//	    }
+//	}
+//
+// # Authentication
+//
+// Authentication is a multi-step SRP flow: AuthInfo, Auth, optionally
+// AuthTOTP, then ListKeySalts and Unlock. A higher-level Login wrapper
+// is planned (see issue #11).
+//
+// # Cancellation
+//
+// Every networked method takes a context.Context as its first parameter.
+// Cancellation propagates to the underlying HTTP request.
+//
+// # Errors
+//
+// Errors returned from networked methods can be inspected with
+// errors.Is and errors.As against the package's typed errors and
+// sentinels (ErrUnauthorized, ErrNotFound, ErrRateLimited, etc).
+//
+// For non-2xx responses the client returns one of two typed errors:
+//
+//   - *APIError when the response body parses as a Proton error envelope
+//     (the common case). It carries Proton's application-layer Code in
+//     addition to the message.
+//   - *HTTPError when the response body does not parse as a Proton error
+//     envelope (rare — for example, an HTML error page from a misconfigured
+//     proxy or upstream gateway). It carries the HTTP status code.
+//
+// Both wrap the same set of sentinels, so errors.Is(err, ErrUnauthorized)
+// (and friends) works uniformly regardless of which concrete type the
+// caller received.
+//
+// # Logging
+//
+// The Client uses *slog.Logger for diagnostic output. Pass
+// WithLogger(slog.New(slog.DiscardHandler)) to silence (default), or
+// a debug-level logger to see request/response traces. Sensitive headers
+// and bodies (tokens, refresh tokens, SRP proofs) are not logged.
+package protonmail

--- a/events.go
+++ b/events.go
@@ -6,13 +6,22 @@ import (
 	"net/http"
 )
 
+// EventRefresh is a bitmask telling the client to discard cached state and
+// re-fetch a category from scratch. The server sets this when the delta
+// stream cannot describe the change incrementally.
 type EventRefresh int
 
 const (
+	// EventRefreshMail signals the client should re-fetch all mail state.
 	EventRefreshMail EventRefresh = 1 << iota
+	// EventRefreshContacts signals the client should re-fetch all contacts.
 	EventRefreshContacts
 )
 
+// Event is a single page of the change stream returned by GetEvent. Apply
+// Messages and Contacts updates in order, then save ID as the cursor for
+// the next call. Refresh, when non-zero, indicates a category must be
+// re-fetched from scratch instead of patched incrementally.
 type Event struct {
 	ID       string `json:"EventID"`
 	Refresh  EventRefresh
@@ -30,17 +39,26 @@ type Event struct {
 	Notices []string
 }
 
+// EventAction is the kind of change an Event item describes (delete, create,
+// update, or — for messages — a flags-only update).
 type EventAction int
 
 const (
+	// EventDelete indicates the item was deleted.
 	EventDelete EventAction = iota
+	// EventCreate indicates the item was created.
 	EventCreate
+	// EventUpdate indicates the full item was updated.
 	EventUpdate
 
-	// For messages
+	// EventUpdateFlags indicates a message had only its flags / labels
+	// updated; Created is nil and Updated carries the diff.
 	EventUpdateFlags
 )
 
+// EventMessage is a single message-level entry in an Event. Created is set
+// for EventCreate; Updated is set for EventUpdate / EventUpdateFlags. For
+// EventDelete only ID is meaningful.
 type EventMessage struct {
 	ID     string
 	Action EventAction
@@ -51,6 +69,10 @@ type EventMessage struct {
 	Updated *EventMessageUpdate
 }
 
+// EventMessageUpdate is the diff payload describing a Message change in an
+// EventMessage. Pointer-typed fields distinguish "unchanged" (nil) from
+// "explicitly set to zero". For EventUpdateFlags the LabelIDs* fields carry
+// the label-set delta; for EventUpdate LabelIDs is the full new list.
 type EventMessageUpdate struct {
 	Unread       *int
 	Type         *MessageType
@@ -73,6 +95,11 @@ func buildLabelsSet(labelIDs []string) map[string]struct{} {
 	return set
 }
 
+// DiffLabelIDs computes the set of label IDs added and removed relative to
+// current. If the update carries an explicit added/removed pair (the
+// flags-only shape), those are returned verbatim; otherwise the full new
+// LabelIDs list is diffed against current. Returns (nil, nil) when neither
+// shape is present.
 func (update *EventMessageUpdate) DiffLabelIDs(current []string) (added, removed []string) {
 	if update.LabelIDsAdded != nil && update.LabelIDsRemoved != nil {
 		return update.LabelIDsAdded, update.LabelIDsRemoved
@@ -96,6 +123,9 @@ func (update *EventMessageUpdate) DiffLabelIDs(current []string) (added, removed
 	return
 }
 
+// Patch applies update in place to msg. Pointer fields are copied only when
+// non-nil; LabelIDs are replaced (full list) or deltaed (added/removed) as
+// appropriate.
 func (update *EventMessageUpdate) Patch(msg *Message) {
 	msg.Time = update.Time
 	if update.Unread != nil {
@@ -137,6 +167,8 @@ type rawEventMessage struct {
 	Message json.RawMessage `json:",omitempty"`
 }
 
+// UnmarshalJSON decodes an EventMessage, dispatching the embedded Message
+// payload into Created or Updated based on Action.
 func (em *EventMessage) UnmarshalJSON(b []byte) error {
 	var raw rawEventMessage
 	if err := json.Unmarshal(b, &raw); err != nil {
@@ -155,12 +187,18 @@ func (em *EventMessage) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// EventContact is a single contact-level entry in an Event. Contact is set
+// for create / update actions; for EventDelete only ID is meaningful.
 type EventContact struct {
 	ID      string
 	Action  EventAction
 	Contact *Contact
 }
 
+// GetEvent fetches the next page of changes after the given event ID. Pass
+// the empty string (or "latest") to obtain the current event ID without any
+// changes — the conventional way to seed the cursor at start-up. The
+// returned Event.ID is the cursor for the next call.
 func (c *Client) GetEvent(ctx context.Context, last string) (*Event, error) {
 	if last == "" {
 		last = "latest"

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,23 @@
+package protonmail_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/joestump/protonmail-go"
+)
+
+// ExampleNewClient demonstrates the minimum incantation to construct a
+// Client. WithAppVersion is the only required option; "Other" is the
+// generic value the Proton web client itself sends for non-product apps.
+func ExampleNewClient() {
+	c, err := protonmail.NewClient(
+		protonmail.WithAppVersion("Other"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	_ = c
+	fmt.Println("client constructed")
+	// Output: client constructed
+}

--- a/import.go
+++ b/import.go
@@ -11,8 +11,12 @@ import (
 	"net/textproto"
 )
 
+// ImportResult is the per-message outcome of a bulk import, keyed by the
+// caller-supplied message key. Use Err for a quick "any failure?" check.
 type ImportResult map[string]ImportMessageResult
 
+// Err returns the first non-nil per-message error in res, or nil if every
+// message imported successfully.
 func (res ImportResult) Err() error {
 	for _, msgRes := range res {
 		if msgRes.Err != nil {
@@ -22,11 +26,23 @@ func (res ImportResult) Err() error {
 	return nil
 }
 
+// ImportMessageResult is the outcome of a single message in an import batch.
+// On success Err is nil and MessageID is the new server-assigned ID.
 type ImportMessageResult struct {
 	Err       error
 	MessageID string
 }
 
+// Importer streams a batch of RFC 822 messages to the Proton import endpoint.
+// It is constructed by Client.Import, populated by repeated ImportMessage
+// calls, and finalised by Commit.
+//
+// An Importer may not be reused after Commit: a second call to Commit returns
+// ErrImporterClosed (matchable via errors.Is). ImportMessage performs its own
+// per-key bookkeeping and currently returns a bare string error if called
+// twice for the same key or with an unknown key; that error is not
+// errors.Is(ErrImporterClosed) and may become a typed error in a future
+// version.
 type Importer struct {
 	pw       *io.PipeWriter
 	mw       *multipart.Writer
@@ -36,6 +52,10 @@ type Importer struct {
 	result   <-chan ImportResult
 }
 
+// ImportMessage returns an io.Writer to which the caller writes the raw
+// RFC 822 bytes of the message identified by key. key must match one of the
+// keys in the metadata map passed to Client.Import; calling ImportMessage
+// twice with the same key, or with an unknown key, returns an error.
 func (imp *Importer) ImportMessage(ctx context.Context, key string) (io.Writer, error) {
 	if uploaded, ok := imp.uploaded[key]; !ok {
 		return nil, fmt.Errorf("protonmail: unknown import message %q", key)
@@ -67,6 +87,10 @@ func (imp *Importer) close() error {
 	return imp.pw.Close()
 }
 
+// Commit finalises the import and waits for the server response. Every key
+// in the metadata map must have been written via ImportMessage first;
+// otherwise Commit returns an error without contacting the server. Calling
+// Commit a second time returns ErrImporterClosed.
 func (imp *Importer) Commit(ctx context.Context) (ImportResult, error) {
 	if err := imp.close(); err != nil {
 		return nil, err
@@ -85,6 +109,10 @@ func (imp *Importer) Commit(ctx context.Context) (ImportResult, error) {
 	return <-imp.result, nil
 }
 
+// Import begins a bulk import session. metadata maps caller-chosen keys to
+// per-message metadata (Subject, ToList, etc.); the same keys are then used
+// to stream RFC 822 bytes via Importer.ImportMessage. Call Commit on the
+// returned Importer to finalise.
 func (c *Client) Import(ctx context.Context, metadata map[string]*Message) (*Importer, error) {
 	pr, pw := io.Pipe()
 

--- a/keys.go
+++ b/keys.go
@@ -11,26 +11,40 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 )
 
+// PrivateKeyFlags is a bitmask describing what a PrivateKey may be used for
+// (verify-only, encrypt, or both).
 type PrivateKeyFlags int
 
 const (
-	PrivateKeyVerify  PrivateKeyFlags = 1
+	// PrivateKeyVerify indicates the key is allowed to verify signatures.
+	PrivateKeyVerify PrivateKeyFlags = 1
+	// PrivateKeyEncrypt indicates the key is allowed to encrypt and
+	// decrypt.
 	PrivateKeyEncrypt PrivateKeyFlags = 2
 )
 
+// PrivateKey is an armored, locked private key associated with a User or
+// Address. The key is decrypted (in memory) by Unlock; PrivateKey itself
+// always carries the locked form.
 type PrivateKey struct {
-	ID          string
-	Version     int
-	Flags       PrivateKeyFlags
-	PrivateKey  string
+	ID         string
+	Version    int
+	Flags      PrivateKeyFlags
+	PrivateKey string
 	Fingerprint string
-	Primary     int
-	Active      int
-	Token       string
-	Signature   string
+	// Primary is non-zero for the primary key of the user / address.
+	Primary int
+	// Active is non-zero if the key is currently active (vs revoked or
+	// pending activation).
+	Active    int
+	Token     string
+	Signature string
 	// TODO: Fingerprints, PublicKey, Activation
 }
 
+// Entity parses the armored private key and returns the first OpenPGP entity
+// in it. The returned entity is still locked; pass it through openpgp's
+// Decrypt or use the unlocking helpers in this package.
 func (priv *PrivateKey) Entity() (*openpgp.Entity, error) {
 	keyRing, err := openpgp.ReadArmoredKeyRing(strings.NewReader(priv.PrivateKey))
 	if err != nil {
@@ -42,24 +56,36 @@ func (priv *PrivateKey) Entity() (*openpgp.Entity, error) {
 	return keyRing[0], nil
 }
 
+// RecipientType describes whether a public-key lookup target is a Proton
+// (internal) recipient or an external one.
 type RecipientType int
 
 const (
+	// RecipientInternal is a Proton-hosted recipient.
 	RecipientInternal RecipientType = 1
-	RecipientExternal               = 2
+	// RecipientExternal is a non-Proton recipient.
+	RecipientExternal = 2
 )
 
+// PublicKeyResp is the response shape returned by GetPublicKeys: the
+// recipient classification, the MIME type the recipient prefers, and the
+// list of usable public keys.
 type PublicKeyResp struct {
 	RecipientType RecipientType
 	MIMEType      string
 	Keys          []*PublicKey
 }
 
+// PublicKey is a single armored public key returned by GetPublicKeys. Send
+// is non-zero if the key is currently usable for sending.
 type PublicKey struct {
+	// Send is non-zero if the key is currently usable for sending.
 	Send      int
 	PublicKey string
 }
 
+// Entity parses the armored public key and returns the first OpenPGP entity
+// in it.
 func (pub *PublicKey) Entity() (*openpgp.Entity, error) {
 	keyRing, err := openpgp.ReadArmoredKeyRing(strings.NewReader(pub.PublicKey))
 	if err != nil {
@@ -71,7 +97,9 @@ func (pub *PublicKey) Entity() (*openpgp.Entity, error) {
 	return keyRing[0], nil
 }
 
-// GetPublicKeys retrieves public keys for a user.
+// GetPublicKeys retrieves the public keys associated with email. The
+// returned PublicKeyResp.RecipientType reports whether the recipient is a
+// Proton or external user; Keys is the list of armored public keys.
 func (c *Client) GetPublicKeys(ctx context.Context, email string) (*PublicKeyResp, error) {
 	v := url.Values{}
 	v.Set("Email", email)

--- a/labels.go
+++ b/labels.go
@@ -5,37 +5,62 @@ import (
 	"net/http"
 )
 
+// Built-in system label IDs. These are the well-known identifiers Proton
+// uses for the standard mailbox folders; user-created labels have their own
+// ULID-style IDs returned by ListLabels.
 const (
-	LabelInbox    = "0"
+	// LabelInbox is the Inbox system label.
+	LabelInbox = "0"
+	// LabelAllDraft contains every draft regardless of address.
 	LabelAllDraft = "1"
-	LabelAllSent  = "2"
-	LabelTrash    = "3"
-	LabelSpam     = "4"
-	LabelAllMail  = "5"
-	LabelArchive  = "6"
-	LabelSent     = "7"
-	LabelDraft    = "8"
-	LabelStarred  = "10"
+	// LabelAllSent contains every sent message regardless of address.
+	LabelAllSent = "2"
+	// LabelTrash is the Trash system label.
+	LabelTrash = "3"
+	// LabelSpam is the Spam system label.
+	LabelSpam = "4"
+	// LabelAllMail is the "All Mail" virtual folder containing every
+	// non-trashed message.
+	LabelAllMail = "5"
+	// LabelArchive is the Archive system label.
+	LabelArchive = "6"
+	// LabelSent is the per-address Sent label (compare LabelAllSent).
+	LabelSent = "7"
+	// LabelDraft is the per-address Drafts label (compare LabelAllDraft).
+	LabelDraft = "8"
+	// LabelStarred is the Starred system label.
+	LabelStarred = "10"
 )
 
+// LabelType distinguishes message labels from contact labels.
 type LabelType int
 
 const (
+	// LabelMessage is a label that applies to messages.
 	LabelMessage LabelType = 1
+	// LabelContact is a label that applies to contacts.
 	LabelContact LabelType = 2
 )
 
+// Label is a user-defined or system label/folder.
 type Label struct {
-	ID        string
-	Name      string
-	Color     string
-	Display   int
-	Type      LabelType
+	ID    string
+	Name  string
+	Color string
+	// Display is non-zero if the label is shown in the UI.
+	Display int
+	Type    LabelType
+	// Exclusive is non-zero for folder-style labels (a message can be in
+	// at most one exclusive label).
 	Exclusive int
-	Notify    int
-	Order     int
+	// Notify is non-zero if the user should be notified about new messages
+	// receiving this label.
+	Notify int
+	Order  int
 }
 
+// ListLabels returns every label visible to the current user, including
+// system labels.
 func (c *Client) ListLabels(ctx context.Context) ([]*Label, error) {
 	req, err := c.newRequest(ctx, http.MethodGet, "/labels", nil)
 	if err != nil {

--- a/messages.go
+++ b/messages.go
@@ -16,49 +16,75 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp/packet"
 )
 
+// MessageType classifies a Message's role in the user's mailbox.
 type MessageType int
 
 const (
+	// MessageInbox is a received message.
 	MessageInbox MessageType = iota
+	// MessageDraft is a draft message that has not been sent.
 	MessageDraft
+	// MessageSent is a message the user has sent.
 	MessageSent
+	// MessageInboxAndSent is a message that appears in both Inbox and Sent
+	// (e.g. messages a user sent to themselves).
 	MessageInboxAndSent
 )
 
+// MessageEncryption describes how a Message body is protected.
 type MessageEncryption int
 
 const (
+	// MessageUnencrypted indicates the body is plaintext (no PGP).
 	MessageUnencrypted MessageEncryption = iota
+	// MessageEncryptedInternal indicates encryption to a Proton recipient.
 	MessageEncryptedInternal
+	// MessageEncryptedExternal indicates encryption to an external PGP
+	// recipient.
 	MessageEncryptedExternal
+	// MessageEncryptedOutside indicates Proton's "encrypted-for-outside"
+	// password-protected delivery.
 	MessageEncryptedOutside
 	_
 	_
 	_
+	// MessageEncryptedInlinePGP indicates an inline-PGP encrypted body.
 	MessageEncryptedInlinePGP
+	// MessageEncryptedPGPMIME indicates a PGP/MIME encrypted body.
 	MessageEncryptedPGPMIME
 	_
 	_
 )
 
+// MessageAction is the kind of follow-up action that produced a draft (reply,
+// reply-all, or forward). Used when creating a draft in response to a parent
+// message.
 type MessageAction int
 
 const (
+	// MessageReply marks the draft as a reply to the parent message.
 	MessageReply MessageAction = iota
+	// MessageReplyAll marks the draft as a reply-all.
 	MessageReplyAll
+	// MessageForward marks the draft as a forward of the parent message.
 	MessageForward
 )
 
+// MessageAddress is a single From/To/CC/BCC participant on a message.
 type MessageAddress struct {
 	Address string
 	Name    string
 }
 
+// Message is a Proton mail message — either received, sent, or a draft.
+// The Body field's interpretation depends on IsEncrypted; use Read to
+// transparently decrypt with a key ring.
 type Message struct {
 	ID             string `json:",omitempty"`
 	Order          int64
 	ConversationID string `json:",omitempty"`
 	Subject        string
+	// Unread is non-zero if the message is unread.
 	Unread         int
 	Type           MessageType
 	Sender         *MessageAddress
@@ -66,24 +92,35 @@ type Message struct {
 	Time           Timestamp
 	Size           int64
 	NumAttachments int
+	// IsEncrypted reports how Body is protected. Use Read to decrypt.
 	IsEncrypted    MessageEncryption
 	ExpirationTime Timestamp
-	IsReplied      int
-	IsRepliedAll   int
-	IsForwarded    int
-	SpamScore      int
-	AddressID      string
-	Body           string
-	MIMEType       string `json:",omitempty"`
-	CCList         []*MessageAddress
-	BCCList        []*MessageAddress
-	ReplyTos       []*MessageAddress
-	Header         string `json:",omitempty"`
-	Attachments    []*Attachment
-	LabelIDs       []string
-	ExternalID     string `json:",omitempty"`
+	// IsReplied is non-zero if the user has replied to this message.
+	IsReplied int
+	// IsRepliedAll is non-zero if the user has reply-all'd this message.
+	IsRepliedAll int
+	// IsForwarded is non-zero if the user has forwarded this message.
+	IsForwarded int
+	SpamScore   int
+	AddressID   string
+	// Body is the (possibly encrypted) message body. Its format is governed
+	// by IsEncrypted — use Read to transparently decrypt against a key ring.
+	Body        string
+	MIMEType    string `json:",omitempty"`
+	CCList      []*MessageAddress
+	BCCList     []*MessageAddress
+	ReplyTos    []*MessageAddress
+	Header      string `json:",omitempty"`
+	Attachments []*Attachment
+	LabelIDs    []string
+	ExternalID  string `json:",omitempty"`
 }
 
+// Read decrypts msg.Body against keyring and returns the OpenPGP message
+// details. For unencrypted messages it returns a synthetic MessageDetails
+// whose UnverifiedBody yields msg.Body verbatim. prompt is invoked by the
+// underlying openpgp library when a private key is locked; nil is acceptable
+// when keyring contains only unlocked keys.
 func (msg *Message) Read(keyring openpgp.KeyRing, prompt openpgp.PromptFunction) (*openpgp.MessageDetails, error) {
 	switch msg.IsEncrypted {
 	case MessageUnencrypted:
@@ -124,6 +161,10 @@ func (w *messageWriter) Close() error {
 	return nil
 }
 
+// Encrypt returns a WriteCloser that encrypts data written to it for the
+// given recipients and stores the resulting armored ciphertext on msg.Body
+// when the writer is closed. If signed is non-nil the message is also signed
+// with that entity. The caller must Close the returned writer.
 func (msg *Message) Encrypt(to []*openpgp.Entity, signed *openpgp.Entity) (plaintext io.WriteCloser, err error) {
 	var b bytes.Buffer
 	ciphertext, err := armor.Encode(&b, "PGP MESSAGE", nil)
@@ -144,6 +185,10 @@ func (msg *Message) Encrypt(to []*openpgp.Entity, signed *openpgp.Entity) (plain
 	}, nil
 }
 
+// MessageFilter narrows the result set returned by ListMessages. Zero-valued
+// fields are omitted from the request. Pointer-typed bool fields
+// (Attachments, Starred, Unread) distinguish "unset" (nil) from "explicitly
+// false" (pointer to false).
 type MessageFilter struct {
 	Page     int
 	PageSize int
@@ -167,6 +212,9 @@ type MessageFilter struct {
 	ExternalID   string
 }
 
+// ListMessages returns the page of messages matching filter. total is the
+// number of messages matched across all pages, messages is the current page.
+// Pass a zero-value *MessageFilter to list with server defaults.
 func (c *Client) ListMessages(ctx context.Context, filter *MessageFilter) (total int, messages []*Message, err error) {
 	v := url.Values{}
 	if filter.Page != 0 {
@@ -214,12 +262,17 @@ func (c *Client) ListMessages(ctx context.Context, filter *MessageFilter) (total
 	return respData.Total, respData.Messages, nil
 }
 
+// MessageCount carries per-label totals for an address: total messages and
+// the number unread.
 type MessageCount struct {
 	LabelID string
 	Total   int
 	Unread  int
 }
 
+// CountMessages returns per-label message counts. If address is empty,
+// counts are aggregated across all addresses on the account; otherwise they
+// are scoped to that address ID.
 func (c *Client) CountMessages(ctx context.Context, address string) ([]*MessageCount, error) {
 	v := url.Values{}
 	if address != "" {
@@ -241,6 +294,9 @@ func (c *Client) CountMessages(ctx context.Context, address string) ([]*MessageC
 	return respData.Counts, nil
 }
 
+// GetMessage fetches a single message by ID, including its body and
+// attachment metadata. Returns a wrapped ErrNotFound if no such message
+// exists.
 func (c *Client) GetMessage(ctx context.Context, id string) (*Message, error) {
 	req, err := c.newRequest(ctx, http.MethodGet, "/messages/"+id, nil)
 	if err != nil {
@@ -258,8 +314,18 @@ func (c *Client) GetMessage(ctx context.Context, id string) (*Message, error) {
 	return respData.Message, nil
 }
 
-// CreateDraftMessage creates a new draft message. ToList, CCList, BCCList,
-// Subject, Body and AddressID are required in msg.
+// CreateDraftMessage creates a draft message.
+//
+// The Proton API expects msg to carry at minimum a Subject, a sender
+// (Sender or AddressID), and a Body; recipients (ToList / CCList / BCCList)
+// are required for any draft you intend to send. This client does not
+// validate msg before sending — missing fields surface as an *APIError
+// from the server.
+//
+// parentID may be empty for a fresh draft, or set to the ID of a parent
+// message to thread the draft as a reply. The current implementation
+// hardcodes Action=MessageReply when parentID is non-empty; reply-all and
+// forward semantics are not yet wired through (see also SendMessage).
 func (c *Client) CreateDraftMessage(ctx context.Context, msg *Message, parentID string) (*Message, error) {
 	var actionPtr *MessageAction
 	if parentID != "" {
@@ -289,6 +355,9 @@ func (c *Client) CreateDraftMessage(ctx context.Context, msg *Message, parentID 
 	return respData.Message, nil
 }
 
+// UpdateDraftMessage updates an existing draft. msg.ID must identify the
+// draft to update. The returned Message reflects the server's view after
+// update.
 func (c *Client) UpdateDraftMessage(ctx context.Context, msg *Message) (*Message, error) {
 	reqData := struct {
 		Message *Message
@@ -322,22 +391,32 @@ func (c *Client) doMessages(ctx context.Context, action string, ids []string) er
 	return c.doJSON(ctx, req, nil)
 }
 
+// MarkMessagesRead marks the given message IDs as read in a single batch
+// request.
 func (c *Client) MarkMessagesRead(ctx context.Context, ids []string) error {
 	return c.doMessages(ctx, "read", ids)
 }
 
+// MarkMessagesUnread marks the given message IDs as unread in a single batch
+// request.
 func (c *Client) MarkMessagesUnread(ctx context.Context, ids []string) error {
 	return c.doMessages(ctx, "unread", ids)
 }
 
+// DeleteMessages soft-deletes the given message IDs (move to Trash). Use
+// UndeleteMessages to reverse, or call again from the Trash to permanently
+// delete.
 func (c *Client) DeleteMessages(ctx context.Context, ids []string) error {
 	return c.doMessages(ctx, "delete", ids)
 }
 
+// UndeleteMessages restores soft-deleted messages by ID.
 func (c *Client) UndeleteMessages(ctx context.Context, ids []string) error {
 	return c.doMessages(ctx, "undelete", ids)
 }
 
+// LabelMessages applies labelID to every message ID in ids. To remove a
+// label, use UnlabelMessages.
 func (c *Client) LabelMessages(ctx context.Context, labelID string, ids []string) error {
 	reqData := struct {
 		LabelID string
@@ -352,6 +431,7 @@ func (c *Client) LabelMessages(ctx context.Context, labelID string, ids []string
 	return c.doJSON(ctx, req, nil)
 }
 
+// UnlabelMessages removes labelID from every message ID in ids.
 func (c *Client) UnlabelMessages(ctx context.Context, labelID string, ids []string) error {
 	reqData := struct {
 		LabelID string
@@ -366,24 +446,43 @@ func (c *Client) UnlabelMessages(ctx context.Context, labelID string, ids []stri
 	return c.doJSON(ctx, req, nil)
 }
 
+// MessageKeyPacket pairs a message ID with its base64-encoded key packets.
 type MessageKeyPacket struct {
 	ID         string
 	KeyPackets string
 }
 
+// MessagePackageType is a bitmask describing how a single recipient's
+// message package is encoded. It is OR'd into MessagePackageSet.Type to
+// describe all delivery modes used in a send.
 type MessagePackageType int
 
 const (
-	MessagePackageInternal         MessagePackageType = 1
-	MessagePackageEncryptedOutside                    = 2
-	MessagePackageCleartext                           = 4
-	MessagePackageInlinePGP                           = 8
-	MessagePackagePGPMIME                             = 16
-	MessagePackageMIME                                = 32
+	// MessagePackageInternal is delivery to a Proton recipient using the
+	// Proton internal protocol.
+	MessagePackageInternal MessagePackageType = 1
+	// MessagePackageEncryptedOutside is Proton's encrypted-for-outside
+	// password-protected delivery.
+	MessagePackageEncryptedOutside = 2
+	// MessagePackageCleartext is unencrypted delivery to an external
+	// recipient.
+	MessagePackageCleartext = 4
+	// MessagePackageInlinePGP is inline-PGP delivery to a non-Proton PGP
+	// recipient.
+	MessagePackageInlinePGP = 8
+	// MessagePackagePGPMIME is PGP/MIME delivery to a non-Proton PGP
+	// recipient.
+	MessagePackagePGPMIME = 16
+	// MessagePackageMIME indicates a MIME-formatted package (not separately
+	// encrypted by Proton).
+	MessagePackageMIME = 32
 )
 
 // From https://github.com/ProtonMail/WebClient/blob/public/src/app/composer/services/encryptMessage.js
 
+// MessagePackage carries the per-recipient encryption material for an
+// outgoing message: the body key packet and any attachment key packets,
+// encrypted to that recipient's key.
 type MessagePackage struct {
 	Type MessagePackageType
 
@@ -392,13 +491,22 @@ type MessagePackage struct {
 	Signature            int
 }
 
+// MessagePackageSet is the per-MIME-type container of recipient packages
+// that, together, make up an outgoing message. It is constructed by
+// NewMessagePackageSet, populated via Encrypt and AddCleartext / AddInternal,
+// and carried inside an OutgoingMessage to SendMessage.
 type MessagePackageSet struct {
-	Type      MessagePackageType // OR of each Type
+	// Type is the OR of each recipient package's Type, describing all
+	// delivery modes used.
+	Type      MessagePackageType
 	Addresses map[string]*MessagePackage
 	MIMEType  string
-	Body      string // Encrypted body data packet
+	// Body is the encrypted body data packet (base64-encoded).
+	Body string
 
-	// Only if cleartext is sent
+	// BodyKey and AttachmentKeys are populated only when at least one
+	// cleartext recipient has been added; they carry the symmetric keys in
+	// the clear so the API can forward them to the recipient.
 	BodyKey        *PackedKey            `json:",omitempty"`
 	AttachmentKeys map[string]*PackedKey `json:",omitempty"`
 
@@ -407,11 +515,17 @@ type MessagePackageSet struct {
 	signature      int
 }
 
+// PackedKey is a base64-encoded symmetric key alongside the cipher algorithm
+// it was generated for (e.g. "aes256").
 type PackedKey struct {
 	Algorithm string
 	Key       string
 }
 
+// NewMessagePackageSet constructs an empty MessagePackageSet sharing the
+// supplied attachment keys. Call Encrypt to populate the body, then add
+// recipient packages via AddInternal (Proton recipients) or AddCleartext
+// (external unencrypted recipients).
 func NewMessagePackageSet(attachmentKeys map[string]*packet.EncryptedKey) *MessagePackageSet {
 	return &MessagePackageSet{
 		Addresses:      make(map[string]*MessagePackage),
@@ -442,8 +556,10 @@ func (w *outgoingMessageWriter) Close() error {
 	return nil
 }
 
-// Encrypt encrypts the data that will be written to the returned
-// io.WriteCloser, and optionally signs it.
+// Encrypt returns a WriteCloser that encrypts the data written to it under
+// a freshly-generated symmetric key, optionally signs it with signed, and
+// stores the resulting base64-encoded ciphertext on set.Body when closed.
+// mimeType is recorded on the set for downstream packaging.
 func (set *MessagePackageSet) Encrypt(mimeType string, signed *openpgp.Entity) (io.WriteCloser, error) {
 	set.MIMEType = mimeType
 
@@ -500,6 +616,10 @@ func cipherFunctionString(cipherFunc packet.CipherFunction) string {
 	}
 }
 
+// AddCleartext registers an external recipient that should receive the
+// message in cleartext. It also populates BodyKey and AttachmentKeys on the
+// set the first time it is called, since cleartext recipients need the
+// symmetric keys delivered separately.
 func (set *MessagePackageSet) AddCleartext(addr string) (*MessagePackage, error) {
 	pkg := &MessagePackage{
 		Type:      MessagePackageCleartext,
@@ -540,6 +660,9 @@ func serializeEncryptedKey(symKey *packet.EncryptedKey, pub *packet.PublicKey, c
 	return encoded.String(), nil
 }
 
+// AddInternal registers a Proton recipient at addr whose body and attachment
+// key packets are encrypted to pub. Encrypt must have been called on the set
+// first to generate the symmetric keys.
 func (set *MessagePackageSet) AddInternal(addr string, pub *openpgp.Entity) (*MessagePackage, error) {
 	config := &packet.Config{}
 
@@ -573,15 +696,30 @@ func (set *MessagePackageSet) AddInternal(addr string, pub *openpgp.Entity) (*Me
 	return pkg, nil
 }
 
+// OutgoingMessage is the payload submitted to SendMessage. ID identifies the
+// draft that is being sent; Packages is the per-MIME-type set of recipient
+// packages constructed via NewMessagePackageSet.
 type OutgoingMessage struct {
+	// ID is the draft message ID being sent. The draft must already exist
+	// (see CreateDraftMessage / UpdateDraftMessage).
 	ID string
 
-	// Only if message expires
-	ExpirationTime int // Duration in seconds
+	// ExpirationTime, if non-zero, sets a self-destruct duration in seconds
+	// after which Proton will delete the message.
+	ExpirationTime int
 
 	Packages []*MessagePackageSet
 }
 
+// SendMessage sends a draft. msg.ID must identify an existing draft
+// (CreateDraftMessage). On success it returns the now-sent Message and, if
+// the draft is threaded to a parent, the parent message reflecting any
+// IsReplied / IsForwarded updates returned by the server.
+//
+// SendMessage itself does not distinguish reply / reply-all / forward — the
+// MessageAction is fixed when the draft is created via CreateDraftMessage
+// (currently always MessageReply when a parentID is supplied). SendMessage
+// just POSTs the OutgoingMessage payload to the existing draft ID.
 func (c *Client) SendMessage(ctx context.Context, msg *OutgoingMessage) (sent, parent *Message, err error) {
 	req, err := c.newJSONRequest(ctx, http.MethodPost, "/messages/"+msg.ID, msg)
 	if err != nil {

--- a/protonmail.go
+++ b/protonmail.go
@@ -1,4 +1,3 @@
-// Package protonmail implements a ProtonMail API client.
 package protonmail
 
 import (
@@ -16,6 +15,8 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 )
 
+// Version is the Proton API version this client speaks. It is sent on every
+// request as the X-Pm-Apiversion header.
 const Version = 3
 
 const headerAPIVersion = "X-Pm-Apiversion"
@@ -32,6 +33,10 @@ type resp struct {
 	*RawAPIError
 }
 
+// Err returns a non-nil *APIError when the response carried a Proton
+// error envelope, or nil otherwise. It is also promoted onto exported
+// types that embed resp (for example AuthInfoResp), so callers can
+// invoke Err() on those response types directly.
 func (r *resp) Err() error {
 	if err := r.RawAPIError; err != nil {
 		return &APIError{
@@ -46,12 +51,25 @@ type maybeError interface {
 	Err() error
 }
 
+// RawAPIError is the JSON shape Proton uses to carry a human-readable error
+// message in a response envelope. Most callers should not need to handle this
+// directly — it is wrapped into an *APIError before being surfaced.
 type RawAPIError struct {
 	Message string `json:"Error"`
 }
 
+// APIError is an application-layer error returned by the Proton API: a
+// non-2xx response whose body parsed as a Proton error envelope. It carries
+// Proton's numeric "Code" (a 4-digit application code, distinct from the HTTP
+// status) and a human-readable Message. Use errors.Is against the package
+// sentinels (ErrUnauthorized, ErrNotFound, ErrRateLimited) rather than
+// switching on Code directly; the sentinel check walks through to the wrapped
+// *HTTPError when Proton's application code is unknown.
 type APIError struct {
-	Code    int
+	// Code is Proton's application-layer error code. It is NOT an HTTP
+	// status; see errors.go for the small set the package recognises.
+	Code int
+	// Message is Proton's human-readable error description.
 	Message string
 
 	// HTTPError, if non-nil, carries the underlying HTTP-level failure
@@ -70,8 +88,11 @@ func (err *APIError) Error() string {
 	return fmt.Sprintf("[%v] %v", err.Code, err.Message)
 }
 
+// Timestamp is a Unix timestamp in seconds, as returned by the Proton API.
+// Use Time to convert to a time.Time.
 type Timestamp int64
 
+// Time returns the Timestamp as a time.Time in the local time zone.
 func (t Timestamp) Time() time.Time {
 	return time.Unix(int64(t), 0)
 }
@@ -95,7 +116,8 @@ type Client struct {
 // NewClient constructs a Client. WithAppVersion is required; all other options
 // have sensible defaults (base URL = https://mail.proton.me/api,
 // User-Agent = "protonmail-go/<version>", logger discards, HTTP client =
-// http.DefaultClient).
+// http.DefaultClient). Options are applied in order; the first option that
+// returns an error aborts construction.
 func NewClient(opts ...Option) (*Client, error) {
 	c := &Client{
 		baseURL:    defaultBaseURL,

--- a/users.go
+++ b/users.go
@@ -5,22 +5,40 @@ import (
 	"net/http"
 )
 
+// User describes the authenticated Proton account: quota, billing summary,
+// and the user-level private keys.
 type User struct {
-	ID         string
-	Name       string
-	UsedSpace  int64
-	Currency   string // e.g. EUR
-	Credit     int
-	MaxSpace   int64
-	MaxUpload  int
-	Role       int // TODO
-	Private    int
-	Subscribed int // TODO
-	Services   int // TODO
+	ID   string
+	Name string
+	// UsedSpace is the number of bytes currently consumed.
+	UsedSpace int64
+	// Currency is the ISO currency code for billing (e.g. "EUR").
+	Currency string
+	// Credit is the prepaid credit on the account, in the smallest unit of
+	// Currency.
+	Credit int
+	// MaxSpace is the storage quota, in bytes.
+	MaxSpace int64
+	// MaxUpload is the maximum upload size in bytes.
+	MaxUpload int
+	// Role is the account role; concrete values are not yet enumerated by
+	// this client.
+	Role int
+	// Private is non-zero if the account uses self-managed (private)
+	// password mode.
+	Private int
+	// Subscribed is a bitmask of subscribed Proton services.
+	Subscribed int
+	// Services is a bitmask of services available to the account.
+	Services int
+	// Delinquent is non-zero if the account is in a delinquent billing
+	// state.
 	Delinquent int
 	Keys       []*PrivateKey
 }
 
+// GetCurrentUser returns the User record for the currently authenticated
+// account.
 func (c *Client) GetCurrentUser(ctx context.Context) (*User, error) {
 	req, err := c.newRequest(ctx, http.MethodGet, "/users", nil)
 	if err != nil {


### PR DESCRIPTION
Closes #9

Final v0.2 milestone PR. Documents the (now-stable) v0.2 API surface so pkg.go.dev renders cleanly.

### What changed
- New `doc.go`: package overview with Status / Quickstart / Authentication / Cancellation / Errors / Logging sections.
- New `example_test.go` with a runnable `ExampleNewClient` (renders on pkg.go.dev).
- godoc comments on every exported type, function, method, constant, and variable across 13 files (`addresses.go`, `attachments.go`, `auth.go`, `calendar.go`, `contacts.go`, `conversations.go`, `events.go`, `import.go`, `keys.go`, `labels.go`, `messages.go`, `protonmail.go`, `users.go`).
- Inline godoc on non-obvious struct fields (`Unread`, `IsReplied`, `Active`, `Primary`, `Body`, `KeyPackets`, etc.). Trivial fields (`ID`, `Name`, `Email`) intentionally left undocumented per Go convention.
- Diff: 618 insertions / 90 deletions across 15 files. No logic changes.

### Acceptance
- [x] `go doc github.com/joestump/protonmail-go` shows package overview with all 6 sections
- [x] Every exported symbol has a comment beginning with the symbol name (verified by AST-style scan; 0 missing)
- [x] `ExampleNewClient` compiles and runs (verified via `go test -run ExampleNewClient`)
- [x] `go build`, `go vet`, `go test ./...` all clean

### Pair-programming flow
- Implementer: Driver agent
- Reviewer: Navigator agent (verdict: APPROVE)

### Closes the v0.2 — foundations milestone
With this merge, all 10 v0.2 issues (#1 ioutil, #2 ctx, #3 errors, #4 HTTP body, #5 NewClient, #6 slog, #7 tests, #8 CI, #9 godoc, #10 README) are merged.